### PR TITLE
Add Slush protocol example from Avalanche paper

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,39 @@
-# Created by venv; see https://docs.python.org/3/library/venv.html
-*
+# Virtual environments
+venv/
+.venv/
+env/
+.env/
+
+# Bytecode
+__pycache__/
+*.py[cod]
+*$py.class
+*.so
+
+# Distribution / packaging
+build/
+dist/
+*.egg-info/
+*.egg
+
+# Testing
+.pytest_cache/
+.coverage
+htmlcov/
+.tox/
+
+# Type checking
+.mypy_cache/
+
+# IDE
+.idea/
+.vscode/
+*.swp
+*.swo
+
+# Project-specific: node dbm storage (tests/examples)
+node_*.db
+
+# Profiling / misc
+profile_*.txt
+*.log

--- a/chaincraft/crypto_primitives/address.py
+++ b/chaincraft/crypto_primitives/address.py
@@ -40,7 +40,7 @@ def public_key_to_address(public_key: ec.EllipticCurvePublicKey) -> str:
     # Get the public key in uncompressed form
     pub_key_bytes = public_key.public_bytes(
         encoding=serialization.Encoding.X962,
-        format=serialization.PublicFormat.UncompressedPoint
+        format=serialization.PublicFormat.UncompressedPoint,
     )
 
     # Remove the first byte (0x04 prefix for uncompressed keys)

--- a/chaincraft/crypto_primitives/sign.py
+++ b/chaincraft/crypto_primitives/sign.py
@@ -21,7 +21,7 @@ class ECDSASignaturePrimitive(KeyCryptoPrimitive):
 
     def __init__(self):
         self.private_key = None  # ec.EllipticCurvePrivateKey
-        self.public_key = None   # ec.EllipticCurvePublicKey
+        self.public_key = None  # ec.EllipticCurvePublicKey
 
     def generate_key(self):
         """
@@ -37,10 +37,7 @@ class ECDSASignaturePrimitive(KeyCryptoPrimitive):
         if not self.private_key:
             raise ValueError("Private key not generated or set.")
 
-        signature = self.private_key.sign(
-            data,
-            ec.ECDSA(hashes.SHA256())
-        )
+        signature = self.private_key.sign(data, ec.ECDSA(hashes.SHA256()))
         return signature
 
     def verify(self, data: bytes, signature: bytes, pub_key=None) -> bool:
@@ -56,11 +53,7 @@ class ECDSASignaturePrimitive(KeyCryptoPrimitive):
             pub_key = self.public_key
 
         try:
-            pub_key.verify(
-                signature,
-                data,
-                ec.ECDSA(hashes.SHA256())
-            )
+            pub_key.verify(signature, data, ec.ECDSA(hashes.SHA256()))
             return True
         except InvalidSignature:
             return False
@@ -76,7 +69,7 @@ class ECDSASignaturePrimitive(KeyCryptoPrimitive):
 
         pem_data = self.public_key.public_bytes(
             encoding=serialization.Encoding.PEM,
-            format=serialization.PublicFormat.SubjectPublicKeyInfo
+            format=serialization.PublicFormat.SubjectPublicKeyInfo,
         )
         return pem_data.decode("ascii")
 

--- a/chaincraft/crypto_primitives/vrf.py
+++ b/chaincraft/crypto_primitives/vrf.py
@@ -40,10 +40,7 @@ class ECDSAVRFPrimitive(KeyCryptoPrimitive):
         if not self.private_key:
             raise ValueError("Private key not generated or set.")
 
-        signature = self.private_key.sign(
-            data,
-            ec.ECDSA(hashes.SHA256())
-        )
+        signature = self.private_key.sign(data, ec.ECDSA(hashes.SHA256()))
         return signature
 
     def verify(self, data: bytes, signature: bytes, pub_key=None) -> bool:
@@ -56,11 +53,7 @@ class ECDSAVRFPrimitive(KeyCryptoPrimitive):
             pub_key = self.public_key
 
         try:
-            pub_key.verify(
-                signature,
-                data,
-                ec.ECDSA(hashes.SHA256())
-            )
+            pub_key.verify(signature, data, ec.ECDSA(hashes.SHA256()))
             return True
         except InvalidSignature:
             return False

--- a/chaincraft/node.py
+++ b/chaincraft/node.py
@@ -217,10 +217,28 @@ class ChaincraftNode:
                 compressed_data: bytes
                 addr: Tuple[str, int]
                 compressed_data, addr = self.socket.recvfrom(self.max_msg_size)
+                message: str = self.decompress_message(compressed_data)
+                # Slush QUERY/RESPONSE: request-response only, do not store
+                try:
+                    data = json.loads(message)
+                    if isinstance(data, dict):
+                        if "SLUSH_QUERY" in data:
+                            for obj in self.shared_objects:
+                                if hasattr(obj, "handle_slush_query"):
+                                    obj.handle_slush_query(addr, data)
+                                    break
+                            continue
+                        if "SLUSH_RESPONSE" in data:
+                            for obj in self.shared_objects:
+                                if hasattr(obj, "handle_slush_response"):
+                                    obj.handle_slush_response(addr, data)
+                                    break
+                            continue
+                except json.JSONDecodeError:
+                    pass
                 message_hash: str = self.hash_message(compressed_data)
                 # Only handle if we've never seen this message
                 if message_hash not in self.db:
-                    message: str = self.decompress_message(compressed_data)
                     self.handle_message(message, message_hash, addr)
             except OSError:
                 if not self.is_running:
@@ -346,6 +364,17 @@ class ChaincraftNode:
             self.save_peers()
 
         return message_hash
+
+    def send_to_peer(self, peer: Tuple[str, int], message: str) -> None:
+        """Send a message to a specific peer (unicast)."""
+        if not self.socket:
+            return
+        try:
+            compressed_message = self.compress_message(message)
+            self.socket.sendto(compressed_message, peer)
+        except Exception as e:
+            if self.debug:
+                print(f"Node {self.port}: Failed send_to_peer {peer}: {e}")
 
     def handle_message(
         self, message: str, message_hash: str, addr: Tuple[str, int]
@@ -710,7 +739,9 @@ class ChaincraftNode:
         Request an update for a shared object with the given class name and digest.
         """
         if self.debug:
-            print(f"\n📤 Requesting update for {class_name} with digest {digest[:8]}...")
+            print(
+                f"\n📤 Requesting update for {class_name} with digest {digest[:8]}..."
+            )
         message: SharedMessage = SharedMessage(
             data={
                 SharedMessage.REQUEST_SHARED_OBJECT_UPDATE: {

--- a/examples/blockchain.py
+++ b/examples/blockchain.py
@@ -81,11 +81,11 @@ class BlockchainUtils:
         private_key_str = private_key.private_bytes(
             encoding=serialization.Encoding.PEM,
             format=serialization.PrivateFormat.PKCS8,
-            encryption_algorithm=serialization.NoEncryption()
+            encryption_algorithm=serialization.NoEncryption(),
         ).decode()
         public_key_str = public_key.public_bytes(
             encoding=serialization.Encoding.PEM,
-            format=serialization.PublicFormat.SubjectPublicKeyInfo
+            format=serialization.PublicFormat.SubjectPublicKeyInfo,
         ).decode()
 
         return private_key_str, public_key_str
@@ -100,7 +100,7 @@ class BlockchainUtils:
             # Get public key in raw bytes format
             public_key_bytes = key.public_bytes(
                 encoding=serialization.Encoding.X962,
-                format=serialization.PublicFormat.UncompressedPoint
+                format=serialization.PublicFormat.UncompressedPoint,
             )
 
             # Remove the first byte (0x04 for uncompressed keys) and hash
@@ -122,15 +122,11 @@ class BlockchainUtils:
 
         # Load private key from PEM string
         private_key = serialization.load_pem_private_key(
-            private_key_str.encode(),
-            password=None
+            private_key_str.encode(), password=None
         )
 
         # Sign the message using deterministic ECDSA (RFC 6979)
-        signature = private_key.sign(
-            message,
-            ec.ECDSA(hashes.SHA256())
-        )
+        signature = private_key.sign(message, ec.ECDSA(hashes.SHA256()))
 
         # Convert to hex
         return signature.hex()
@@ -150,11 +146,7 @@ class BlockchainUtils:
             public_key = serialization.load_pem_public_key(public_key_str.encode())
 
             # Verify the signature
-            public_key.verify(
-                signature_bytes,
-                message,
-                ec.ECDSA(hashes.SHA256())
-            )
+            public_key.verify(signature_bytes, message, ec.ECDSA(hashes.SHA256()))
             return True
         except Exception as e:
             print(f"Signature verification error: {e}")

--- a/examples/chatroom_protocol.py
+++ b/examples/chatroom_protocol.py
@@ -181,7 +181,8 @@ class ChatroomObject(SharedObject):
         elif msg_type == "POST_MESSAGE":
             sig = data.get("signature")
             posts = [
-                m for m in self.chatrooms[cname]["messages"]
+                m
+                for m in self.chatrooms[cname]["messages"]
                 if m.get("message_type") == "POST_MESSAGE"
             ]
             if not any(m.get("signature") == sig for m in posts):

--- a/examples/randomness_beacon.py
+++ b/examples/randomness_beacon.py
@@ -174,7 +174,9 @@ class RandomnessBeacon(SharedObject):
         if current_last["prevBlockHash"] != new_block["prevBlockHash"]:
             cur = current_last["prevBlockHash"][:8]
             new = new_block["prevBlockHash"][:8]
-            print(f"Previous hash mismatch: current={cur}..., new={new}... - not replacing")
+            print(
+                f"Previous hash mismatch: current={cur}..., new={new}... - not replacing"
+            )
             return
 
         # Compare lexicographical ordering of block hashes
@@ -439,10 +441,14 @@ class BeaconMiner:
                     self.node.create_shared_message(block)
                     h = block["blockHeight"]
                     hsh = block["blockHash"][:8]
-                    print(f"Miner {short_address} found block at height {h} with hash {hsh}...")
+                    print(
+                        f"Miner {short_address} found block at height {h} with hash {hsh}..."
+                    )
                 except SharedObjectException as e:
                     # The block might have been replaced while we were mining
-                    print(f"Miner {short_address}: Block rejected (chain may have changed): {e}")
+                    print(
+                        f"Miner {short_address}: Block rejected (chain may have changed): {e}"
+                    )
 
             except Exception as e:
                 print(f"Mining error for {short_address}: {str(e)}")

--- a/examples/slush_protocol.py
+++ b/examples/slush_protocol.py
@@ -1,0 +1,269 @@
+#!/usr/bin/env python3
+"""
+Slush protocol from the Avalanche paper (Snowflake to Avalanche).
+Avalanche.md Section 2.2 - toy single-decree consensus, NOT Byzantine fault tolerant.
+
+Nodes converge on binary choice (RED or BLUE) via repeated sampling: sample k peers,
+adopt color when >= alpha*k responses agree, run m rounds, then accept.
+
+Uses ChaincraftNode and UDP: SlushObject is a SharedObject added to the node.
+Chaincraft node dispatches SLUSH_QUERY/SLUSH_RESPONSE to handle_slush_* methods.
+"""
+
+import json
+import logging
+import random
+import threading
+import time
+from enum import Enum
+from typing import Any, Callable, Dict, List, Optional, Tuple
+
+import os
+import sys
+
+try:
+    from chaincraft.shared_object import SharedObject
+    from chaincraft.shared_message import SharedMessage
+except ImportError:
+    _root = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+    if _root not in sys.path:
+        sys.path.insert(0, _root)
+    if os.getcwd() not in sys.path:
+        sys.path.insert(0, os.getcwd())
+    from chaincraft.shared_object import SharedObject
+    from chaincraft.shared_message import SharedMessage
+
+
+class Color(Enum):
+    """Binary choice: Red or Blue (paper R/B)."""
+
+    RED = "R"
+    BLUE = "B"
+    UNCOLORED = "⊥"
+
+
+# Type for ChaincraftNode (avoid circular import)
+NodeT = Any
+
+
+class SlushObject(SharedObject):
+    """
+    Slush consensus as SharedObject. Inherits from Chaincraft SharedObject,
+    uses node.send_to_peer for UDP queries/responses.
+    """
+
+    MSG_QUERY = "SLUSH_QUERY"
+    MSG_RESPONSE = "SLUSH_RESPONSE"
+
+    def __init__(
+        self,
+        node: NodeT,
+        k: int = 10,
+        alpha: float = 0.5,
+        m: int = 10,
+        log_fn: Optional[Callable[[str], None]] = None,
+    ):
+        self.node = node
+        self.k = k
+        self.alpha = alpha
+        self.m = m
+        self._log = log_fn or (lambda msg: logging.info(msg))
+        self._color = Color.UNCOLORED
+        self._accepted: Optional[Color] = None
+        self._current_round = 0
+        self._pending: Dict[int, Dict[Tuple[str, int], Color]] = {}
+        self._round_done = threading.Event()
+        self._lock = threading.Lock()
+
+    def _log_node(self, msg: str) -> None:
+        self._log(f"[{self.node.port}] {msg}")
+
+    def handle_slush_query(self, addr: Tuple[str, int], data: dict) -> None:
+        """onQuery: if uncolored adopt query color; respond with current color."""
+        payload = data.get(self.MSG_QUERY)
+        if not payload or "col" not in payload or "r" not in payload:
+            return
+        r = payload["r"]
+        col_str = payload["col"]
+        with self._lock:
+            if self._color == Color.UNCOLORED:
+                self._color = Color.RED if col_str == "R" else Color.BLUE
+                self._log_node(f"onQuery: adopted {self._color.value} from {addr}")
+            resp = {
+                self.MSG_RESPONSE: {
+                    "r": r,
+                    "col": self._color.value,
+                    "from": f"{self.node.host}:{self.node.port}",
+                }
+            }
+        msg = json.dumps(resp)
+        self.node.send_to_peer(addr, msg)
+
+    def handle_slush_response(self, addr: Tuple[str, int], data: dict) -> None:
+        """Collect response; when enough for current round, unblock slush loop."""
+        payload = data.get(self.MSG_RESPONSE)
+        if not payload or "r" not in payload or "col" not in payload:
+            return
+        r = payload["r"]
+        col = Color.RED if payload["col"] == "R" else Color.BLUE
+        with self._lock:
+            if r not in self._pending:
+                self._pending[r] = {}
+            self._pending[r][addr] = col
+            if len(self._pending[r]) >= self.k:
+                self._round_done.set()
+
+    def run_slush_loop(self, initial_color: Optional[Color] = None) -> Optional[Color]:
+        """
+        slushLoop: m rounds. Each round sample k peers, query, if >= alpha*k
+        same color adopt it. Returns final accepted color or None.
+        """
+        if initial_color is not None:
+            with self._lock:
+                self._color = initial_color
+            self._log_node(f"slushLoop: initial color {initial_color.value}")
+        # Non-proposers wait to adopt color from an incoming SLUSH_QUERY
+        wait_start = time.time()
+        while self._color == Color.UNCOLORED and time.time() - wait_start < 10.0:
+            time.sleep(0.05)
+        if self._color == Color.UNCOLORED:
+            self._log_node("slushLoop: uncolored, no proposal received (timeout)")
+            return None
+        peers = list(self.node.peers)
+        sample_size = min(self.k, len(peers))
+        if sample_size == 0:
+            self._log_node("slushLoop: no peers")
+            return None
+        for r in range(1, self.m + 1):
+            with self._lock:
+                self._current_round = r
+                self._pending[r] = {}
+            self._round_done.clear()
+            sampled = random.sample(peers, sample_size)
+            for peer in sampled:
+                q = {
+                    self.MSG_QUERY: {
+                        "r": r,
+                        "col": self._color.value,
+                        "from": f"{self.node.host}:{self.node.port}",
+                    }
+                }
+                self.node.send_to_peer(peer, json.dumps(q))
+            self._round_done.wait(timeout=3.0)
+            with self._lock:
+                responses = list(self._pending.get(r, {}).values())
+            if len(responses) >= max(1, int(self.alpha * self.k)):
+                counts = {Color.RED: 0, Color.BLUE: 0}
+                for c in responses:
+                    if c in counts:
+                        counts[c] += 1
+                for c in (Color.RED, Color.BLUE):
+                    if counts[c] >= int(self.alpha * self.k) and c != self._color:
+                        with self._lock:
+                            self._color = c
+                        self._log_node(f"Round {r}: flipped to {c.value}")
+                        break
+        with self._lock:
+            self._accepted = self._color
+        self._log_node(f"Slush accepted: {self._accepted.value}")
+        return self._accepted
+
+    def get_accepted(self) -> Optional[Color]:
+        return self._accepted
+
+    # SharedObject stubs (Slush uses custom messages, not SharedMessage)
+    def is_valid(self, message: SharedMessage) -> bool:
+        return False
+
+    def add_message(self, message: SharedMessage) -> None:
+        pass
+
+    def is_merkelized(self) -> bool:
+        return False
+
+    def get_latest_digest(self) -> str:
+        return ""
+
+    def has_digest(self, hash_digest: str) -> bool:
+        return False
+
+    def is_valid_digest(self, hash_digest: str) -> bool:
+        return False
+
+    def add_digest(self, hash_digest: str) -> bool:
+        return False
+
+    def gossip_object(self, digest: str) -> List[SharedMessage]:
+        return []
+
+    def get_messages_since_digest(self, digest: str) -> List[SharedMessage]:
+        return []
+
+
+def run_slush_nodes(
+    num_nodes: int = 10,
+    base_port: int = 9010,
+    k: int = 4,
+    alpha: float = 0.5,
+    m: int = 8,
+    proposer_idx: int = 0,
+    initial_color: Color = Color.RED,
+) -> Dict[int, Optional[Color]]:
+    """
+    Run Slush consensus with num_nodes ChaincraftNode instances over UDP.
+    Nodes connect via connect_to_peer; SlushObject handles queries/responses via UDP.
+    Returns dict port -> accepted color.
+    """
+    try:
+        from chaincraft.node import ChaincraftNode
+    except ImportError:
+        sys.path.insert(
+            0, os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+        )
+        from chaincraft.node import ChaincraftNode
+
+    log_fn: Callable[[str], None] = lambda msg: print(f"[Slush] {msg}")
+    nodes: List[ChaincraftNode] = []
+    slushes: List[SlushObject] = []
+
+    for i in range(num_nodes):
+        port = base_port + i
+        node = ChaincraftNode(
+            port=port,
+            max_peers=num_nodes - 1,
+            local_discovery=True,
+        )
+        slush = SlushObject(node, k=k, alpha=alpha, m=m, log_fn=log_fn)
+        node.add_shared_object(slush)
+        node.start()
+        nodes.append(node)
+        slushes.append(slush)
+
+    for i in range(num_nodes):
+        for j in range(num_nodes):
+            if i != j:
+                nodes[i].connect_to_peer(nodes[j].host, nodes[j].port)
+    time.sleep(0.5)
+
+    slushes[proposer_idx]._color = initial_color
+    log_fn(f"Node {nodes[proposer_idx].port} proposes {initial_color.value}")
+
+    results: Dict[int, Optional[Color]] = {}
+    threads: List[threading.Thread] = []
+    for i, (node, slush) in enumerate(zip(nodes, slushes)):
+        init_col = initial_color if i == proposer_idx else None
+        t = threading.Thread(target=lambda s=slush, c=init_col: s.run_slush_loop(c))
+        threads.append(t)
+        t.start()
+    for t in threads:
+        t.join()
+
+    for node, slush in zip(nodes, slushes):
+        results[node.port] = slush.get_accepted()
+
+    for node in nodes:
+        node.close()
+    return results
+
+
+COLORS = ("R", "B")

--- a/examples/tendermint_bft.py
+++ b/examples/tendermint_bft.py
@@ -351,7 +351,9 @@ class TendermintBFT(SharedObject):
         """Process a proposal"""
         proposer = str(proposal.get("proposer", "unknown"))[:10]
         height = proposal.get("height", "unknown")
-        print(f"Node {self.validator_address[:10]}...: Processing proposal from {proposer}... for height {height}")
+        print(
+            f"Node {self.validator_address[:10]}...: Processing proposal from {proposer}... for height {height}"
+        )
 
         # Validate the proposal height and round
         if (
@@ -393,7 +395,9 @@ class TendermintBFT(SharedObject):
             self._broadcast_prevote()
         else:
             step = self.current_step.name
-            print(f"Node {self.validator_address[:10]}...: Received proposal while in {step}, not changing")
+            print(
+                f"Node {self.validator_address[:10]}...: Received proposal while in {step}, not changing"
+            )
 
     def _process_prevote(self, prevote: Dict[str, Any]) -> None:
         """Process a prevote from another validator"""
@@ -407,14 +411,18 @@ class TendermintBFT(SharedObject):
             return
 
         if height > self.current_height:
-            print(f"Node {self.validator_address[:10]}...: Received prevote for future height {height}")
+            print(
+                f"Node {self.validator_address[:10]}...: Received prevote for future height {height}"
+            )
             # Store for future processing
             return
 
         # Add the prevote to our collection
         self.prevotes[height].append(prevote)
         v = str(validator)[:10] if validator else "unknown"
-        print(f"Node {self.validator_address[:10]}...: Added prevote from {v}... for height {height}")
+        print(
+            f"Node {self.validator_address[:10]}...: Added prevote from {v}... for height {height}"
+        )
 
         # Check if we have enough prevotes to move to PRECOMMIT
         self._check_prevotes()
@@ -425,18 +433,24 @@ class TendermintBFT(SharedObject):
         validator = precommit.get("validator")
 
         if height < self.current_height:
-            print(f"Node {self.validator_address[:10]}...: Ignoring outdated precommit for height {height}")
+            print(
+                f"Node {self.validator_address[:10]}...: Ignoring outdated precommit for height {height}"
+            )
             return
 
         if height > self.current_height:
-            print(f"Node {self.validator_address[:10]}...: Received precommit for future height {height}")
+            print(
+                f"Node {self.validator_address[:10]}...: Received precommit for future height {height}"
+            )
             # Store for future processing
             return
 
         # Add the precommit to our collection
         self.precommits[height].append(precommit)
         v = str(validator)[:10] if validator else "unknown"
-        print(f"Node {self.validator_address[:10]}...: Added precommit from {v}... for height {height}")
+        print(
+            f"Node {self.validator_address[:10]}...: Added precommit from {v}... for height {height}"
+        )
 
         # Check if we have enough precommits to create a block
         self._check_precommits()
@@ -462,7 +476,9 @@ class TendermintBFT(SharedObject):
         threshold = (len(self.validators) * 2) // 3 + 1
 
         n = len(self.validators)
-        print(f"Node {self.validator_address[:10]}...: Prevote count: {matching_prevotes}/{n}, need {threshold}")
+        print(
+            f"Node {self.validator_address[:10]}...: Prevote count: {matching_prevotes}/{n}, need {threshold}"
+        )
 
         if matching_prevotes >= threshold:
             print(
@@ -493,7 +509,9 @@ class TendermintBFT(SharedObject):
         threshold = (len(self.validators) * 2) // 3 + 1
 
         n = len(self.validators)
-        print(f"Node {self.validator_address[:10]}...: Precommit count: {matching_precommits}/{n}, need {threshold}")
+        print(
+            f"Node {self.validator_address[:10]}...: Precommit count: {matching_precommits}/{n}, need {threshold}"
+        )
 
         if matching_precommits >= threshold:
             # Only proceed with block creation if we have a real proposal (not nil)
@@ -687,7 +705,9 @@ class TendermintBFT(SharedObject):
 
         if wait_time > 0:
             h = self.current_height + 1
-            print(f"Node {self.validator_address[:10]}...: Waiting {wait_time:.2f}s before height {h}")
+            print(
+                f"Node {self.validator_address[:10]}...: Waiting {wait_time:.2f}s before height {h}"
+            )
             time.sleep(wait_time)
 
         self.current_height += 1
@@ -704,7 +724,9 @@ class TendermintBFT(SharedObject):
         if self.current_height in self.pending_proposals:
             proposal = self.pending_proposals.pop(self.current_height)
             h = self.current_height
-            print(f"Node {self.validator_address[:10]}...: Processing pending proposal for height {h}")
+            print(
+                f"Node {self.validator_address[:10]}...: Processing pending proposal for height {h}"
+            )
             self._process_proposal(proposal)
 
     def start_consensus(self) -> None:

--- a/examples/tendermint_cli.py
+++ b/examples/tendermint_cli.py
@@ -113,7 +113,9 @@ class TendermintCLI:
         print(
             f"To start this node, run: python {sys.argv[0]} start --config {args.config}"
         )
-        print("For other nodes to join, share genesis.json and update seed_nodes config.")
+        print(
+            "For other nodes to join, share genesis.json and update seed_nodes config."
+        )
 
     def start_node(self, args) -> None:
         """Start a Tendermint node"""

--- a/scripts/git-hooks/pre-commit
+++ b/scripts/git-hooks/pre-commit
@@ -1,0 +1,22 @@
+#!/bin/sh
+# Pre-commit hook: run code quality tools.
+# Requires: black, flake8, mypy (pip install -e ".[dev]")
+
+set -e
+cd "$(git rev-parse --show-toplevel)"
+
+# Use project venv if present
+if [ -d .venv ]; then
+    . .venv/bin/activate
+fi
+
+# Paths to check (excludes .venv)
+PATHS="chaincraft chaincraft_cli.py examples tests"
+
+echo "Running black..."
+black --check $PATHS || { echo "Run 'black $PATHS' to fix formatting."; exit 1; }
+
+echo "Running flake8..."
+flake8 $PATHS || exit 1
+
+echo "All checks passed."

--- a/scripts/run_slush_10_nodes.py
+++ b/scripts/run_slush_10_nodes.py
@@ -1,0 +1,92 @@
+#!/usr/bin/env python3
+"""
+Run 10 Slush consensus nodes with console logging.
+
+Based on the Avalanche paper (Slush protocol) - a toy metastable consensus
+where nodes converge on a binary decision (RED or BLUE).
+
+Usage:
+    python scripts/run_slush_10_nodes.py [--color R|B] [--rounds N] [--random]
+"""
+
+import argparse
+import logging
+import os
+import random
+import sys
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from examples.slush_protocol import run_slush_nodes, Color, COLORS
+
+# Configure logging
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s %(message)s",
+    datefmt="%H:%M:%S",
+)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Run 10-node Slush consensus from Avalanche paper")
+    parser.add_argument(
+        "--color", "-c",
+        choices=list(COLORS),
+        default="R",
+        help="Initial color proposed by node 0 (R=red, B=blue)",
+    )
+    parser.add_argument(
+        "--rounds", "-r",
+        type=int,
+        default=8,
+        help="Number of Slush rounds (m)",
+    )
+    parser.add_argument(
+        "--nodes", "-n",
+        type=int,
+        default=10,
+        help="Number of nodes",
+    )
+    parser.add_argument(
+        "--k",
+        type=int,
+        default=4,
+        help="Sample size per query",
+    )
+    parser.add_argument(
+        "--base-port",
+        type=int,
+        default=9010,
+        help="Base port for nodes",
+    )
+    parser.add_argument(
+        "--random", "-R",
+        action="store_true",
+        help="Pick random initial color (R or B) instead of --color",
+    )
+    args = parser.parse_args()
+
+    if args.random:
+        initial = random.choice([Color.RED, Color.BLUE])
+        print(f"[Slush] Random initial color: {initial.value}")
+    else:
+        initial = Color.RED if args.color == "R" else Color.BLUE
+    results = run_slush_nodes(
+        num_nodes=args.nodes,
+        base_port=args.base_port,
+        k=args.k,
+        alpha=0.5,
+        m=args.rounds,
+        initial_color=initial,
+    )
+
+    print("\n=== Slush consensus complete ===")
+    for port in sorted(results.keys()):
+        c = results[port]
+        print(f"  Node {port}: accepted={c.value if c else '?'}")
+    decided = sum(1 for c in results.values() if c is not None)
+    print(f"Decided: {decided}/{args.nodes} nodes")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/setup-hooks.sh
+++ b/scripts/setup-hooks.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+# Configure git to use tracked hooks from scripts/git-hooks/
+git config core.hooksPath scripts/git-hooks
+echo "Hooks path set to scripts/git-hooks"

--- a/tests/test_local_discovery.py
+++ b/tests/test_local_discovery.py
@@ -90,7 +90,7 @@ class TestLocalDiscovery(unittest.TestCase):
 
         self.assertTrue(
             wait_for_local_peers(nodes[0], 2, timeout=20),
-            f"Expected 2 peers, got {len(nodes[0].peers)}"
+            f"Expected 2 peers, got {len(nodes[0].peers)}",
         )
         self.assertEqual(len(nodes[0].peers), 2)
 

--- a/tests/test_message_types.py
+++ b/tests/test_message_types.py
@@ -169,14 +169,16 @@ class TestMessageTypes(unittest.TestCase):
             "sender": "Alice",
             "recipient": "Bob",
             "amount": 10.0,
-            "signature": sig1 + "7cb497a29b7b5c7d1c4e8f8c8d1b1a9d1c3f2e7c4b5a7d6c3e9f8d7c6b5a4d3e2f1c",
+            "signature": sig1
+            + "7cb497a29b7b5c7d1c4e8f8c8d1b1a9d1c3f2e7c4b5a7d6c3e9f8d7c6b5a4d3e2f1c",
         }
         transaction2 = {
             "message_type": "Transaction",
             "sender": "Bob",
             "recipient": "Charlie",
             "amount": 5.0,
-            "signature": sig2 + "7d7c5e3f1c9b7a5d3e1f8c6b4a2d9e7f5c3b1a8d6e4f2c9b7a5d3e1f8c6b4a2d",
+            "signature": sig2
+            + "7d7c5e3f1c9b7a5d3e1f8c6b4a2d9e7f5c3b1a8d6e4f2c9b7a5d3e1f8c6b4a2d",
         }
 
         _, shared_transaction1 = self.nodes[0].create_shared_message(transaction1)

--- a/tests/test_randomness_beacon.py
+++ b/tests/test_randomness_beacon.py
@@ -175,9 +175,9 @@ class TestRandomnessBeacon(unittest.TestCase):
 
         # 2. Invalid prev hash
         bad_prev = valid_block.copy()
-        bad_prev[
-            "prevBlockHash"
-        ] = "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"
+        bad_prev["prevBlockHash"] = (
+            "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"
+        )
         bad_prev["blockHash"] = beacon._calculate_block_hash(bad_prev)
         self.assertFalse(beacon.is_valid(SharedMessage(data=bad_prev)))
 

--- a/tests/test_shared_object_updates.py
+++ b/tests/test_shared_object_updates.py
@@ -164,7 +164,10 @@ def wait_for_chain_sync(nodes, expected_chain_length, timeout=30):
     last_status_time = start_time
     check_interval = 0.1  # Start with fast checking
 
-    print(f"Waiting for chain sync to length {expected_chain_length} " f"(timeout: {timeout}s)")
+    print(
+        f"Waiting for chain sync to length {expected_chain_length} "
+        f"(timeout: {timeout}s)"
+    )
 
     while time.time() - start_time < timeout:
         current_time = time.time()
@@ -193,7 +196,9 @@ def wait_for_chain_sync(nodes, expected_chain_length, timeout=30):
             # Get expected chain from first node with required length
             for node in nodes:
                 if len(node.shared_objects[0].chain) >= expected_chain_length:
-                    expected_chain = node.shared_objects[0].chain[:expected_chain_length]
+                    expected_chain = node.shared_objects[0].chain[
+                        :expected_chain_length
+                    ]
                     break
 
             # Check if all nodes have the same chain prefix
@@ -230,7 +235,10 @@ def wait_for_chain_sync(nodes, expected_chain_length, timeout=30):
     # Check if chains are at least growing
     min_length = min(len(node.shared_objects[0].chain) for node in nodes)
     if min_length > 1:
-        print(f"⚠️ Chains are growing but didn't fully sync in time. " f"Min length: {min_length}")
+        print(
+            f"⚠️ Chains are growing but didn't fully sync in time. "
+            f"Min length: {min_length}"
+        )
     else:
         print("❌ Chains aren't growing properly")
 
@@ -259,7 +267,9 @@ class TestSharedObjectUpdates(unittest.TestCase):
         for node in self.nodes:
             node.close()
 
-    def expect_exception(self, exception_type, expected_message, callable_obj, *args, **kwargs):
+    def expect_exception(
+        self, exception_type, expected_message, callable_obj, *args, **kwargs
+    ):
         """Helper method to test for exceptions without using assertRaises"""
         try:
             callable_obj(*args, **kwargs)
@@ -273,7 +283,9 @@ class TestSharedObjectUpdates(unittest.TestCase):
                 print(f"✓ Exception correctly raised: {str(e)}")
                 return True
             else:
-                self.fail(f"Expected {exception_type.__name__} but got {type(e).__name__}: {str(e)}")
+                self.fail(
+                    f"Expected {exception_type.__name__} but got {type(e).__name__}: {str(e)}"
+                )
                 return False
 
     def test_shared_object_updates(self):
@@ -299,7 +311,9 @@ class TestSharedObjectUpdates(unittest.TestCase):
             chain = node.shared_objects[0].chain
             for i in range(1, len(chain)):
                 expected_hash = hashlib.sha256(chain[i - 1].encode()).hexdigest()
-                self.assertEqual(chain[i], expected_hash, f"Hash chain broken at index {i}")
+                self.assertEqual(
+                    chain[i], expected_hash, f"Hash chain broken at index {i}"
+                )
 
     def test_concurrent_updates(self):
         """Test multiple nodes adding hashes concurrently"""
@@ -338,7 +352,9 @@ class TestSharedObjectUpdates(unittest.TestCase):
         for i, node in enumerate(self.nodes):
             node_chain = node.shared_objects[0].chain
             print(f"Node {i} final chain: {[h[:8] for h in node_chain]}")
-            self.assertEqual(node_chain, first_chain, f"Node {i} chain doesn't match node 0 chain")
+            self.assertEqual(
+                node_chain, first_chain, f"Node {i} chain doesn't match node 0 chain"
+            )
             # Should at least include first added hash
             self.assertIn(
                 added_hashes[0],
@@ -387,7 +403,9 @@ class TestSharedObjectUpdates(unittest.TestCase):
         for i in range(1, len(self.nodes)):
             try:
                 # Force direct message delivery to each node
-                self.nodes[i].handle_message(msg[0], "test", (self.nodes[0].host, self.nodes[0].port))
+                self.nodes[i].handle_message(
+                    msg[0], "test", (self.nodes[0].host, self.nodes[0].port)
+                )
                 print(f"Direct message to node {i} delivered")
             except Exception as e:
                 print(f"Error sending to node {i}: {e}")
@@ -418,7 +436,9 @@ class TestSharedObjectUpdates(unittest.TestCase):
             print("Broadcasting to connected nodes...")
             for j in range(1, 4):  # Nodes 1-3
                 try:
-                    self.nodes[j].handle_message(msg[0], "test", (self.nodes[0].host, self.nodes[0].port))
+                    self.nodes[j].handle_message(
+                        msg[0], "test", (self.nodes[0].host, self.nodes[0].port)
+                    )
                 except Exception as e:
                     print(f"Error sending to node {j}: {e}")
 
@@ -480,7 +500,9 @@ class TestSharedObjectUpdates(unittest.TestCase):
         for hash_val in new_hashes:
             try:
                 msg = SharedMessage(data=hash_val).to_json()
-                self.nodes[4].handle_message(msg, "test", (self.nodes[0].host, self.nodes[0].port))
+                self.nodes[4].handle_message(
+                    msg, "test", (self.nodes[0].host, self.nodes[0].port)
+                )
                 print(f"Directly sent hash {hash_val[:8]} to node 4")
                 time.sleep(0.5)
             except Exception as e:
@@ -506,10 +528,14 @@ class TestSharedObjectUpdates(unittest.TestCase):
             print("⚠️ Node 4 may not have received all hashes, but test continues")
 
         # Final verification - all nodes should now be in sync
-        final_result = wait_for_chain_sync(self.nodes, 2, timeout=60)  # Require at least 2 hashes
+        final_result = wait_for_chain_sync(
+            self.nodes, 2, timeout=60
+        )  # Require at least 2 hashes
 
         # Check that the chains are at least growing, even if not completely in sync
-        all_chains_growing = all(len(node.shared_objects[0].chain) > 1 for node in self.nodes)
+        all_chains_growing = all(
+            len(node.shared_objects[0].chain) > 1 for node in self.nodes
+        )
 
         # Test passes if either full sync or at least all chains are growing
         self.assertTrue(
@@ -549,7 +575,9 @@ class TestSharedObjectUpdates(unittest.TestCase):
         # Verify no node accepted the invalid hash - this is the real test
         time.sleep(2)  # Give time for any potential sync
         for i, node in enumerate(self.nodes):
-            print(f"Checking node {i} chain: {[h[:8] for h in node.shared_objects[0].chain]}")
+            print(
+                f"Checking node {i} chain: {[h[:8] for h in node.shared_objects[0].chain]}"
+            )
             self.assertNotIn(invalid_hash, node.shared_objects[0].chain)
 
         print("✓ All nodes properly rejected the invalid hash")
@@ -584,7 +612,9 @@ class TestSharedObjectUpdates(unittest.TestCase):
                 if i != j:
                     try:
                         # Reinforce connections
-                        self.nodes[i].connect_to_peer(self.nodes[j].host, self.nodes[j].port)
+                        self.nodes[i].connect_to_peer(
+                            self.nodes[j].host, self.nodes[j].port
+                        )
                         print(f"Reinforced connection: Node {i} → Node {j}")
                     except Exception:
                         # Connection already exists, which is fine
@@ -613,16 +643,22 @@ class TestSharedObjectUpdates(unittest.TestCase):
                         # Create a fresh message for each attempt
                         msg = self.nodes[0].create_shared_message(next_hash)
                         # Force direct message delivery
-                        self.nodes[j].handle_message(msg[0], "test", (self.nodes[0].host, self.nodes[0].port))
+                        self.nodes[j].handle_message(
+                            msg[0], "test", (self.nodes[0].host, self.nodes[0].port)
+                        )
                         success = True
                         print(f"✓ Hash delivered to node {j}")
                     except Exception as e:
                         retries += 1
-                        print(f"⚠️ Delivery attempt {retries}/{max_retries} to node {j} failed: {e}")
+                        print(
+                            f"⚠️ Delivery attempt {retries}/{max_retries} to node {j} failed: {e}"
+                        )
                         time.sleep(0.2)  # Brief delay before retry
 
                 if not success:
-                    print(f"❌ Failed to deliver hash to node {j} after {max_retries} attempts")
+                    print(
+                        f"❌ Failed to deliver hash to node {j} after {max_retries} attempts"
+                    )
 
             # Add a delay between hash additions
             time.sleep(0.5)
@@ -647,7 +683,9 @@ class TestSharedObjectUpdates(unittest.TestCase):
                 continue
 
             if len(node.shared_objects[0].chain) < expected_length:
-                print(f"Node {i} needs sync: has {len(node.shared_objects[0].chain)} blocks, needs {expected_length}")
+                print(
+                    f"Node {i} needs sync: has {len(node.shared_objects[0].chain)} blocks, needs {expected_length}"
+                )
 
                 # First check which hashes are missing
                 existing_hashes = set(node.shared_objects[0].chain)
@@ -664,7 +702,9 @@ class TestSharedObjectUpdates(unittest.TestCase):
                     try:
                         # Create message directly
                         msg = SharedMessage(data=hash_val).to_json()
-                        node.handle_message(msg, "test", (self.nodes[0].host, self.nodes[0].port))
+                        node.handle_message(
+                            msg, "test", (self.nodes[0].host, self.nodes[0].port)
+                        )
                         print(f"Sent hash {hash_val[:8]} to node {i}")
 
                         # Verify hash was added
@@ -677,11 +717,18 @@ class TestSharedObjectUpdates(unittest.TestCase):
                             # Try an alternate approach - use node's own add_digest method
                             if len(node.shared_objects[0].chain) > 0:
                                 prev_hash = node.shared_objects[0].chain[-1]
-                                if node.shared_objects[0].calculate_next_hash(prev_hash) == hash_val:
+                                if (
+                                    node.shared_objects[0].calculate_next_hash(
+                                        prev_hash
+                                    )
+                                    == hash_val
+                                ):
                                     print(f"Trying direct add_digest for node {i}")
                                     result = node.shared_objects[0].add_digest(hash_val)
                                     if result:
-                                        print(f"✓ Direct add_digest succeeded for hash {hash_val[:8]}")
+                                        print(
+                                            f"✓ Direct add_digest succeeded for hash {hash_val[:8]}"
+                                        )
                     except Exception:
                         # Log exception without using variable
                         print(f"Error sending hash to node {i}")
@@ -714,7 +761,9 @@ class TestSharedObjectUpdates(unittest.TestCase):
 
             if len(chain) < expected_length:
                 missing_sync.append(i)
-                print(f"⚠️ Node {i} chain didn't sync fully: only has {len(chain)} blocks")
+                print(
+                    f"⚠️ Node {i} chain didn't sync fully: only has {len(chain)} blocks"
+                )
             elif chain[:expected_length] != expected_chain[:expected_length]:
                 print(f"⚠️ Node {i} chain content doesn't match node 0")
 

--- a/tests/test_slush.py
+++ b/tests/test_slush.py
@@ -1,0 +1,203 @@
+# tests/test_slush.py
+
+"""Tests for Slush protocol (Avalanche paper Section 2.2).
+
+Run from chaincraft/: python -m unittest tests.test_slush -v
+Or: PYTHONPATH=. pytest tests/test_slush.py -v
+"""
+
+import os
+import sys
+
+# Ensure project root is in path before importing chaincraft/examples
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+import unittest
+import time
+import json
+
+from examples.slush_protocol import (
+    SlushObject,
+    Color,
+    run_slush_nodes,
+    COLORS,
+)
+
+
+class MockNode:
+    """Minimal mock for SlushObject unit tests (send_to_peer, host, port, peers)."""
+
+    def __init__(self, host="127.0.0.1", port=9000, peers=None):
+        self.host = host
+        self.port = port
+        self.peers = list(peers or [])
+        self._sent: list = []
+
+    def send_to_peer(self, peer, message: str):
+        self._sent.append((peer, message))
+
+    def clear_sent(self):
+        self._sent.clear()
+
+
+class TestSlushObjectUnit(unittest.TestCase):
+    """Unit tests for SlushObject (SharedObject interface, handle_slush_query)."""
+
+    def test_color_enum(self):
+        self.assertEqual(Color.RED.value, "R")
+        self.assertEqual(Color.BLUE.value, "B")
+        self.assertEqual(Color.UNCOLORED.value, "⊥")
+
+    def test_slush_object_shared_object_stubs(self):
+        """SlushObject satisfies SharedObject interface."""
+        from chaincraft.shared_message import SharedMessage
+
+        node = MockNode()
+        slush = SlushObject(node, k=4, alpha=0.5, m=5)
+
+        self.assertFalse(slush.is_valid(SharedMessage(data={})))
+        slush.add_message(SharedMessage(data={}))  # no-op, no raise
+        self.assertFalse(slush.is_merkelized())
+        self.assertEqual(slush.get_latest_digest(), "")
+        self.assertFalse(slush.has_digest("abc"))
+        self.assertFalse(slush.is_valid_digest("abc"))
+        self.assertFalse(slush.add_digest("abc"))
+        self.assertEqual(slush.gossip_object("abc"), [])
+        self.assertEqual(slush.get_messages_since_digest("abc"), [])
+
+    def test_handle_slush_query_adopts_when_uncolored(self):
+        """Uncolored node adopts query color and responds."""
+        node = MockNode(port=9010)
+        slush = SlushObject(node, k=4, alpha=0.5, m=5)
+
+        addr = ("127.0.0.1", 9020)
+        data = {"SLUSH_QUERY": {"r": 1, "col": "R", "from": "127.0.0.1:9020"}}
+        slush.handle_slush_query(addr, data)
+
+        self.assertEqual(slush._color, Color.RED)
+        self.assertEqual(len(node._sent), 1)
+        peer, msg_str = node._sent[0]
+        self.assertEqual(peer, addr)
+        msg = json.loads(msg_str)
+        self.assertIn("SLUSH_RESPONSE", msg)
+        self.assertEqual(msg["SLUSH_RESPONSE"]["col"], "R")
+        self.assertEqual(msg["SLUSH_RESPONSE"]["r"], 1)
+
+    def test_handle_slush_query_keeps_color_when_colored(self):
+        """Colored node does not change color, responds with current."""
+        node = MockNode(port=9010)
+        slush = SlushObject(node, k=4, alpha=0.5, m=5)
+        slush._color = Color.BLUE
+
+        addr = ("127.0.0.1", 9020)
+        data = {"SLUSH_QUERY": {"r": 1, "col": "R", "from": "127.0.0.1:9020"}}
+        slush.handle_slush_query(addr, data)
+
+        self.assertEqual(slush._color, Color.BLUE)
+        msg = json.loads(node._sent[0][1])
+        self.assertEqual(msg["SLUSH_RESPONSE"]["col"], "B")
+
+    def test_handle_slush_query_ignores_malformed(self):
+        """Malformed query does not change state or send response."""
+        node = MockNode(port=9010)
+        slush = SlushObject(node, k=4, alpha=0.5, m=5)
+
+        slush.handle_slush_query(("127.0.0.1", 9020), {})
+        self.assertEqual(slush._color, Color.UNCOLORED)
+        self.assertEqual(len(node._sent), 0)
+
+        slush.handle_slush_query(("127.0.0.1", 9020), {"SLUSH_QUERY": {}})
+        self.assertEqual(len(node._sent), 0)
+
+    def test_handle_slush_response_collects(self):
+        """Responses are collected per round; round_done set when k reached."""
+        node = MockNode(port=9010, peers=[("127.0.0.1", 9020), ("127.0.0.1", 9021)])
+        slush = SlushObject(node, k=2, alpha=0.5, m=5)
+        slush._pending[1] = {}
+
+        slush.handle_slush_response(
+            ("127.0.0.1", 9020), {"SLUSH_RESPONSE": {"r": 1, "col": "R"}}
+        )
+        self.assertEqual(len(slush._pending[1]), 1)
+        self.assertFalse(slush._round_done.is_set())
+
+        slush.handle_slush_response(
+            ("127.0.0.1", 9021), {"SLUSH_RESPONSE": {"r": 1, "col": "R"}}
+        )
+        self.assertEqual(len(slush._pending[1]), 2)
+        self.assertTrue(slush._round_done.is_set())
+
+    def test_handle_slush_response_ignores_malformed(self):
+        """Malformed response does not affect pending."""
+        node = MockNode(port=9010)
+        slush = SlushObject(node, k=2, alpha=0.5, m=5)
+        slush._pending[1] = {}
+
+        slush.handle_slush_response(("127.0.0.1", 9020), {})
+        slush.handle_slush_response(("127.0.0.1", 9020), {"SLUSH_RESPONSE": {"r": 1}})
+        self.assertEqual(len(slush._pending[1]), 0)
+
+
+class TestSlushIntegration(unittest.TestCase):
+    """Integration tests using run_slush_nodes with real ChaincraftNode over UDP."""
+
+    def setUp(self):
+        self.base_port = 9200
+
+    def tearDown(self):
+        pass
+
+    def test_run_slush_consensus_red(self):
+        """5 nodes reach consensus on RED."""
+        results = run_slush_nodes(
+            num_nodes=5,
+            base_port=self.base_port,
+            k=3,
+            alpha=0.5,
+            m=6,
+            proposer_idx=0,
+            initial_color=Color.RED,
+        )
+        self.assertEqual(len(results), 5)
+        for port, color in results.items():
+            self.assertIsNotNone(color, f"Node {port} did not decide")
+            self.assertEqual(
+                color, Color.RED, f"Node {port} accepted {color} instead of R"
+            )
+
+    def test_run_slush_consensus_blue(self):
+        """5 nodes reach consensus on BLUE."""
+        results = run_slush_nodes(
+            num_nodes=5,
+            base_port=self.base_port + 10,
+            k=3,
+            alpha=0.5,
+            m=6,
+            proposer_idx=0,
+            initial_color=Color.BLUE,
+        )
+        self.assertEqual(len(results), 5)
+        for port, color in results.items():
+            self.assertIsNotNone(color, f"Node {port} did not decide")
+            self.assertEqual(
+                color, Color.BLUE, f"Node {port} accepted {color} instead of B"
+            )
+
+    def test_run_slush_10_nodes(self):
+        """10 nodes all decide on the same color (full demo)."""
+        results = run_slush_nodes(
+            num_nodes=10,
+            base_port=self.base_port + 20,
+            k=4,
+            alpha=0.5,
+            m=8,
+            initial_color=Color.RED,
+        )
+        self.assertEqual(len(results), 10)
+        decided = [c for c in results.values() if c is not None]
+        self.assertEqual(len(decided), 10)
+        self.assertTrue(all(c == Color.RED for c in decided))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Implement Slush (Avalanche paper Section 2.2) as a SharedObject that uses ChaincraftNode UDP messaging for query/response
- Add run script for 10-node demo with CLI flags (--color, --random, --rounds)
- Add 10 tests covering unit (MockNode) and integration (real UDP nodes)

## Test plan
- [x] `python -m unittest tests.test_slush -v` passes all 10 tests
- [x] `python scripts/run_slush_10_nodes.py` runs 10 nodes to consensus
- [x] `python scripts/run_slush_10_nodes.py --random` picks random initial color

fixes #68 