### PR TITLE
v0.5.0: StateMemento pipeline frontier, deep reorg support, and integer-denominated balances

### DIFF
--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -37,7 +37,7 @@ jobs:
     
     - name: Test with pytest
       run: |
-        python -m pytest -q tests/test_core_objects.py tests/test_message_types.py
+        python -m pytest -q tests
   build:
     needs: test
     runs-on: ubuntu-latest

--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -75,5 +75,5 @@ jobs:
         flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
     - name: Test with pytest
       run: |
-        python -m pytest -q tests/test_core_objects.py tests/test_message_types.py
+        python -m pytest -q tests
       shell: /usr/bin/bash -e {0}

--- a/SPECS.md
+++ b/SPECS.md
@@ -1,6 +1,6 @@
-# Chaincraft Protocol Implementation Specification v1
+# Chaincraft Protocol Implementation Specification v2
 
-This document describes how to implement a protocol using Chaincraft.
+This document describes SPECS v2 for implementing a protocol using Chaincraft.
 You write protocol logic only; Chaincraft handles networking, gossip,
 storage, peer management, and concurrency.
 
@@ -21,7 +21,10 @@ storage, peer management, and concurrency.
 │       ├── Gossip path: SharedMessage                          │
 │       │    ├── _handle_shared_message()                       │
 │       │    │    ├── obj.is_valid(msg) for ALL objects         │
-│       │    │    └── obj.add_message(msg) for EACH             │
+│       │    │    └── linear pipeline per object (v2):          │
+│       │    │         obj.add_message(msg, frontier_state?)    │
+│       │    │         -> Optional[StateMemento]                │
+│       │    │         -> passed to next SharedObject           │
 │       │    └── _store_and_broadcast()                         │
 │       │         (store in DB, hash+dedupe, gossip to peers)   │
 │       │                                                       │
@@ -56,10 +59,17 @@ one `SharedObject` subclass.
 
 ```python
 from chaincraft.shared_object import SharedObject
+from chaincraft.state_memento import StateMemento
 
 class MyProtocolObject(SharedObject):
     def is_valid(self, message: SharedMessage) -> bool: ...
-    def add_message(self, message: SharedMessage) -> None: ...
+    def add_message(
+        self,
+        message: SharedMessage,
+        frontier_state: Optional[StateMemento] = None,
+    ) -> Optional[StateMemento]: ...
+    def emit_state_memento(self) -> StateMemento: ...
+    def get_state_digests(self) -> List[str]: ...
     def is_merkelized(self) -> bool: ...
     def get_latest_digest(self) -> str: ...
     def has_digest(self, hash_digest: str) -> bool: ...
@@ -86,12 +96,15 @@ When a peer sends a message to this node:
    - **Validation phase**: calls `obj.is_valid(msg)` on **every**
      SharedObject in the node. If **any** returns `False`, the message
      is rejected and the sender receives a strike (ban after 3 strikes).
-   - **Processing phase**: only if **all** objects validated, calls
-     `obj.add_message(msg)` **sequentially** on each SharedObject in
-     registration order. Each object gets one shot to update its
-     internal state for this message.
+   - **Processing phase**: only if **all** objects validated, process
+     objects **sequentially** in registration order while passing an
+     optional `frontier_state` memento downstream.
    - Then stores and broadcasts (gossips) the message to all peers.
 5. Your `add_message()` runs protocol state transitions.
+
+In v2, `frontier_state` carries canonical/frontier digests between
+SharedObjects so downstream objects can detect reorgs or canonical
+rewrites (including multi-block rewrites) and catch up.
 
 This two-phase design supports nodes with **multiple SharedObjects**
 that represent different facets of the same protocol. A typical example
@@ -112,7 +125,8 @@ When this node creates a message locally:
 
 1. `node.create_shared_message(data)` wraps data in a SharedMessage.
 2. Calls `obj.is_valid(msg)` on all SharedObjects.
-3. If all valid, calls `obj.add_message(msg)` on each.
+3. If all valid, processes shared objects in the same linear pipeline
+   (including optional `frontier_state` propagation).
 4. Broadcasts the message to all peers.
 5. Stores it in the node's DB (deduplicated by hash).
 
@@ -231,13 +245,14 @@ Focus on two methods:
 
 - **`is_valid(msg)`**: Return `True` if this message is well-formed and
   the state transition it represents is legal. This is your validator.
-- **`add_message(msg)`**: The single public entry point from the node.
-  Apply the state transition here. Dispatch internally to private
-  handlers based on message type or content — do not add more public
-  handler methods. For example:
+- **`add_message(msg, frontier_state=None)`**: The single public entry
+  point from the node. Apply the state transition here. Dispatch
+  internally to private handlers based on message type or content — do
+  not add more public handler methods. Legacy objects may still use
+  `add_message(msg)` without `frontier_state`. For example:
 
 ```python
-def add_message(self, message):
+def add_message(self, message, frontier_state=None):
     data = message.data
     if data["blockHeight"] == len(self.blocks) - 1:
         self._handle_replacement(data)
@@ -277,8 +292,9 @@ rejects the message, a `SharedObjectException` is raised.
 The node provides **two public entry points** into your SharedObject,
 both called from the listener thread:
 
-- **`add_message(msg)`** — for gossip-path messages (stored, deduplicated,
-  broadcast). Dispatch to `_private_methods()` internally.
+- **`add_message(msg, frontier_state=None)`** — for gossip-path messages
+  (stored, deduplicated, broadcast). Dispatch to `_private_methods()`
+  internally.
 - **`handle_p2p(addr, data)`** — for ephemeral point-to-point messages
   (not stored, not gossiped). Dispatch to `_private_methods()` internally.
 
@@ -335,7 +351,7 @@ class ChatroomObject(SharedObject):
         ...
         return True
 
-    def add_message(self, message):
+    def add_message(self, message, frontier_state=None):
         # Apply: create room, accept member, store post
         # Optionally notify UI via callback
         if self.on_message_added:

--- a/TODO.md
+++ b/TODO.md
@@ -1,81 +1,27 @@
 # Chaincraft Python — TODO
 
-## SPECS v2 — Changeset support for reorgs
+## SPECS v2 — Frontier Memento pipeline
 
-The current `add_message()` is forward-only. Deep blockchain reorgs
-(e.g. replacing the last 3 blocks with a longer fork) require undoing
-state across multiple SharedObjects (Chain, Ledger, Mempool) atomically.
+Changeset propagation was replaced by a more minimal v2 design:
+**frontier memento propagation** through the same linear pipeline.
 
-**Proposed design**: `add_message()` returns an optional `Changeset` dict
-that is passed to the next SharedObject in the pipeline. This way a
-Chain object detecting a 3-block reorg can emit a changeset specifying
-which blocks were reverted and which transactions need to go back into
-the Mempool or be unwound from the Ledger. Each downstream object
-receives the changeset and acts on it.
+Each `SharedObject` can now publish a compact snapshot containing:
 
-```
-Chain.add_message(block)
-  → detects reorg, reverts 3 blocks internally
-  → returns Changeset {"reverted_blocks": [...], "reverted_txs": [...]}
+- canonical digest
+- frontier list of digests (tips/heads/window)
+- optional revision/metadata
 
-Ledger.add_message(block, changeset)
-  → reverses balance changes for reverted_txs
-  → applies new block balances
+The next `SharedObject` receives that snapshot as `frontier_state`,
+allowing it to detect canonical rewrites (including >1 block/state-step)
+and run local catchup/rollback logic.
 
-Mempool.add_message(block, changeset)
-  → re-adds reverted_txs to the pool
-  → removes newly confirmed txs
-```
-
-This keeps the pipeline model (no orchestrator/coordinator needed) while
-giving each object the context it needs to handle undo + redo.
-
-**Important**: the SharedObject pipeline must remain **linear** — an
-ordered list where each object passes its changeset to the next. If
-objects formed a graph (fan-out, cycles, conditional routing), changeset
-propagation becomes unmanageable: ordering is ambiguous, conflicts are
-hard to resolve, and reversibility breaks down. A linear pipeline is
-simple, predictable, and sufficient for real protocols.
-
-**Changeset as a list of typed operations**: Rather than passing raw
-data blobs, each SharedObject defines a small set of reversible
-operations (its "core operators"). A Changeset is a list of these
-operations — internal messages between objects in the pipeline.
-
-Each operation has a forward and reverse form:
-
-```
-# Ledger operators
-CREDIT_BALANCE(addr, amount)    ↔  DEBIT_BALANCE(addr, amount)
-DEBIT_BALANCE(addr, amount)     ↔  CREDIT_BALANCE(addr, amount)
-
-# Mempool operators
-REMOVE_TX(tx_id)                ↔  RESTORE_TX(tx_id, tx_data)
-ADD_TX(tx_id, tx_data)          ↔  REMOVE_TX(tx_id)
-```
-
-When Chain detects a 3-block reorg, `add_message()` returns a Changeset
-containing the reverse operations for the reverted blocks:
-
-```python
-# Chain.add_message returns:
-Changeset([
-    RESTORE_TX("abc1", tx_data),   # Mempool: put back reverted tx
-    RESTORE_TX("abc2", tx_data),
-    DEBIT_BALANCE("miner_old", 10), # Ledger: undo old miner reward
-    CREDIT_BALANCE("miner_new", 10), # Ledger: apply new miner reward
-])
-```
-
-Each downstream object processes only the operations it recognizes and
-ignores the rest. This is type-safe, auditable, and naturally reversible.
-
-- [ ] Design `Operation` base type (name, params, reverse)
-- [ ] Design `Changeset` as `List[Operation]`
-- [ ] Each SharedObject declares which operation types it handles
-- [ ] Extend `add_message()` signature: `add_message(msg, changeset=None) -> Optional[Changeset]`
-- [ ] Update `_process_shared_objects` in node.py to pass changeset through the pipeline
-- [ ] Add reorg integration test with Chain + Ledger + Mempool
+- [x] Add `StateMemento` value object (Memento pattern)
+- [x] Add `normalize_state_memento(...)` helper
+- [x] Extend base `SharedObject` contract with optional `frontier_state`
+- [x] Add `emit_state_memento()` and `get_state_digests()` defaults
+- [x] Update `_process_shared_objects` in `node.py` to pass frontier state linearly
+- [x] Keep backward compatibility for legacy `add_message(message)` objects
+- [ ] Add full blockchain reorg integration test with Chain + Ledger + Mempool
 
 ## SPECS v1
 

--- a/__init__.py
+++ b/__init__.py
@@ -5,7 +5,7 @@ This package provides the fundamental components needed to create distributed ne
 implement consensus mechanisms, and prototype blockchain applications.
 """
 
-__version__ = "0.4.7"
+__version__ = "0.5.0"
 __author__ = "Chaincraft Contributors"
 __email__ = "chaincraft@example.com"
 

--- a/chaincraft/__init__.py
+++ b/chaincraft/__init__.py
@@ -5,7 +5,7 @@ This package provides the fundamental components needed to create distributed ne
 implement consensus mechanisms, and prototype blockchain applications.
 """
 
-__version__ = "0.4.7"
+__version__ = "0.5.0"
 __author__ = "Chaincraft Contributors"
 __email__ = "chaincraft@example.com"
 
@@ -13,6 +13,7 @@ from .node import ChaincraftNode
 from .shared_object import SharedObject, SharedObjectException
 from .shared_message import SharedMessage
 from .index_helper import IndexHelper
+from .state_memento import StateMemento, normalize_state_memento
 from .core_objects import (
     CoreSharedObject,
     NonMerkelizedObject,
@@ -35,6 +36,8 @@ __all__ = [
     "SharedObjectException",
     "SharedMessage",
     "IndexHelper",
+    "StateMemento",
+    "normalize_state_memento",
     "CoreSharedObject",
     "NonMerkelizedObject",
     "MerkelizedObject",

--- a/chaincraft/core_objects.py
+++ b/chaincraft/core_objects.py
@@ -324,6 +324,15 @@ class MerkelizedObject(CoreSharedObject):
             return ""
         return self._digests[-1]
 
+    def get_state_digests(self) -> List[str]:
+        """
+        Return a short digest frontier window so downstream objects can
+        detect multi-block canonical rewrites.
+        """
+        if not self._digests:
+            return []
+        return self._digests[-8:]
+
     def has_digest(self, hash_digest: str) -> bool:
         return hash_digest in self._digest_index
 
@@ -492,6 +501,9 @@ class DAGObject(MerkelizedObject):
 
     def get_head_digests(self) -> List[str]:
         return list(self._head_digests)
+
+    def get_state_digests(self) -> List[str]:
+        return self.get_head_digests()
 
     def has_digest(self, hash_digest: str) -> bool:
         return (

--- a/chaincraft/node.py
+++ b/chaincraft/node.py
@@ -491,8 +491,20 @@ class ChaincraftNode:
         except json.JSONDecodeError:
             self.handle_invalid_message(addr)
         except Exception as e:
+            if self._is_expected_shutdown_error(e):
+                return
             print(f"❌ Error handling message: {str(e)}")
             self.handle_invalid_message(addr)
+
+    def _is_expected_shutdown_error(self, error: Exception) -> bool:
+        """
+        Return True for socket-close races during shutdown.
+        """
+        if self.is_running:
+            return False
+        if isinstance(error, OSError) and getattr(error, "errno", None) == 9:
+            return True
+        return "Bad file descriptor" in str(error)
 
     def _handle_shared_message(
         self,

--- a/chaincraft/node.py
+++ b/chaincraft/node.py
@@ -1,6 +1,7 @@
 # chaincraft.py
 
 import json
+import inspect
 import random
 import socket
 import threading
@@ -11,6 +12,7 @@ import dbm.ndbm
 import os
 from typing import List, Tuple, Dict, Union, Optional, Any, Set
 
+from .state_memento import StateMemento
 from .shared_object import SharedObject, SharedObjectException
 from .shared_message import SharedMessage
 from .index_helper import IndexHelper
@@ -516,14 +518,38 @@ class ChaincraftNode:
 
     def _process_shared_objects(self, shared_message: SharedMessage) -> None:
         """
-        Add the shared message to each SharedObject.
+        Add the shared message to each SharedObject in a linear pipeline.
+        Each object can emit a frontier memento that is passed to the next object.
         """
+        frontier_state: Optional[StateMemento] = None
         for obj in self.shared_objects:
-            obj.add_message(shared_message)
+            emitted_state: Optional[StateMemento]
+            if self._add_message_supports_frontier_state(obj):
+                emitted_state = obj.add_message(
+                    shared_message, frontier_state=frontier_state
+                )
+            else:
+                obj.add_message(shared_message)
+                emitted_state = None
+
+            if emitted_state is None and hasattr(obj, "emit_state_memento"):
+                emitted_state = obj.emit_state_memento()
+
+            if emitted_state is not None:
+                frontier_state = emitted_state
+
             if self.debug:
                 print(
                     f"Node {self.port}: Added message to shared object {type(obj).__name__}"
                 )
+
+    def _add_message_supports_frontier_state(self, obj: SharedObject) -> bool:
+        """
+        Detect whether a shared object accepts the optional frontier_state argument.
+        """
+        signature = inspect.signature(obj.add_message)
+        parameter_names = list(signature.parameters.keys())
+        return "frontier_state" in parameter_names
 
     def _store_and_broadcast(self, message_hash: str, message_str: str) -> None:
         """
@@ -722,12 +748,7 @@ class ChaincraftNode:
         new_object: SharedMessage = SharedMessage(data=data)
         if self.shared_objects:
             if all(obj.is_valid(new_object) for obj in self.shared_objects):
-                for obj in self.shared_objects:
-                    obj.add_message(new_object)
-                    if self.debug:
-                        print(
-                            f"Node {self.port}: Added message to shared object {type(obj).__name__}"
-                        )
+                self._process_shared_objects(new_object)
             else:
                 raise SharedObjectException("Invalid message for shared objects")
 

--- a/chaincraft/shared_object.py
+++ b/chaincraft/shared_object.py
@@ -1,8 +1,9 @@
 # shared_object.py
 
 from abc import ABC, abstractmethod
-from typing import List
+from typing import List, Optional
 
+from .state_memento import StateMemento, normalize_state_memento
 from .shared_message import SharedMessage
 
 
@@ -16,7 +17,11 @@ class SharedObject(ABC):
         raise SharedObjectException("is_valid method not implemented")
 
     @abstractmethod
-    def add_message(self, message: SharedMessage) -> None:
+    def add_message(
+        self,
+        message: SharedMessage,
+        frontier_state: Optional[StateMemento] = None,
+    ) -> Optional[StateMemento]:
         raise SharedObjectException("add_message method not implemented")
 
     def is_merkelized(self) -> bool:
@@ -39,3 +44,19 @@ class SharedObject(ABC):
 
     def get_messages_since_digest(self, digest: str) -> List[SharedMessage]:
         return []
+
+    def get_state_digests(self) -> List[str]:
+        """
+        Return frontier digests for multi-head structures (DAGs, forks, etc.).
+        By default this falls back to latest digest as a single-head frontier.
+        """
+        latest_digest = self.get_latest_digest()
+        return [latest_digest] if latest_digest else []
+
+    def emit_state_memento(self) -> StateMemento:
+        """
+        Build the shared pipeline snapshot (Memento pattern).
+        """
+        latest_digest = self.get_latest_digest()
+        frontier_digests = self.get_state_digests()
+        return normalize_state_memento(latest_digest, frontier_digests)

--- a/chaincraft/state_memento.py
+++ b/chaincraft/state_memento.py
@@ -1,0 +1,44 @@
+from dataclasses import dataclass, field
+from typing import Any, Iterable, Mapping, Optional, Tuple
+
+
+@dataclass(frozen=True)
+class StateMemento:
+    """
+    Immutable snapshot propagated between SharedObjects in one pipeline pass.
+    """
+
+    canonical_digest: str
+    frontier_digests: Tuple[str, ...] = field(default_factory=tuple)
+    revision: int = 0
+    metadata: Mapping[str, Any] = field(default_factory=dict)
+
+    def indicates_reorg_against(self, previous: Optional["StateMemento"]) -> bool:
+        """
+        Detect canonical replacement between two snapshots.
+        """
+        if previous is None:
+            return False
+        if not previous.canonical_digest or not self.canonical_digest:
+            return False
+        if self.canonical_digest == previous.canonical_digest:
+            return False
+        return previous.canonical_digest not in set(self.frontier_digests)
+
+
+def normalize_state_memento(
+    canonical_digest: str,
+    frontier_digests: Optional[Iterable[str]] = None,
+) -> StateMemento:
+    """
+    Create a normalized memento where frontier digests are unique and sorted.
+    """
+    digests = list(frontier_digests or [])
+    if canonical_digest and canonical_digest not in digests:
+        digests.append(canonical_digest)
+
+    normalized = tuple(sorted({digest for digest in digests if digest}))
+    return StateMemento(
+        canonical_digest=canonical_digest or "",
+        frontier_digests=normalized,
+    )

--- a/examples/__init__.py
+++ b/examples/__init__.py
@@ -4,4 +4,4 @@ Chaincraft Examples - Educational blockchain implementations.
 This package contains example implementations of various blockchain protocols and concepts.
 """
 
-__version__ = "0.4.7"
+__version__ = "0.5.0"

--- a/examples/blockchain.py
+++ b/examples/blockchain.py
@@ -6,15 +6,22 @@ import time
 import os
 import sys
 from dataclasses import dataclass
-from typing import List, Dict, Any, Optional
+from typing import List, Dict, Any, Optional, Set
 
 from cryptography.hazmat.primitives.asymmetric import ec
-from cryptography.hazmat.primitives import hashes, serialization
+from cryptography.hazmat.primitives import serialization
 
 # Try to import from installed package first, fall back to direct imports
 try:
     from chaincraft.core_objects import Mempool as CoreMempool
     from chaincraft.core_objects import Blockchain as CoreBlockchain
+    from chaincraft.crypto_primitives.address import (
+        generate_key_pair,
+        public_key_to_address,
+    )
+    from chaincraft.crypto_primitives.pow import ProofOfWorkPrimitive
+    from chaincraft.crypto_primitives.sign import ECDSASignaturePrimitive
+    from chaincraft.state_memento import StateMemento, normalize_state_memento
     from chaincraft.shared_message import SharedMessage
 except ImportError:
     root = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
@@ -25,9 +32,23 @@ except ImportError:
     try:
         from chaincraft.core_objects import Mempool as CoreMempool
         from chaincraft.core_objects import Blockchain as CoreBlockchain
+        from chaincraft.crypto_primitives.address import (
+            generate_key_pair,
+            public_key_to_address,
+        )
+        from chaincraft.crypto_primitives.pow import ProofOfWorkPrimitive
+        from chaincraft.crypto_primitives.sign import ECDSASignaturePrimitive
+        from chaincraft.state_memento import StateMemento, normalize_state_memento
     except ImportError:
         from chaincraft.shared_object import SharedObject as CoreMempool
         from chaincraft.shared_object import SharedObject as CoreBlockchain
+        from chaincraft.crypto_primitives.address import (
+            generate_key_pair,
+            public_key_to_address,
+        )
+        from chaincraft.crypto_primitives.pow import ProofOfWorkPrimitive
+        from chaincraft.crypto_primitives.sign import ECDSASignaturePrimitive
+        from chaincraft.state_memento import StateMemento, normalize_state_memento
     from chaincraft.shared_message import SharedMessage
 
 
@@ -48,44 +69,29 @@ class BlockchainUtils:
 
     @staticmethod
     def verify_proof_of_work(block_data: Dict, nonce: int, difficulty: int) -> bool:
-        """Verify if a given nonce meets the proof-of-work requirement"""
-        # Create copy of block data without the nonce to create the challenge
-        challenge = {k: v for k, v in block_data.items() if k != "nonce"}
+        """
+        Verify PoW using the shared Chaincraft primitive.
+        """
+        challenge = {k: v for k, v in block_data.items() if k not in ("nonce", "hash")}
         challenge_hash = BlockchainUtils.calculate_hash(challenge)
-
-        # Combine challenge hash with nonce to get final hash
-        final_hash = BlockchainUtils.calculate_hash(challenge_hash + str(nonce))
-
-        # Check if hash meets difficulty (has required number of leading zeros)
-        return final_hash.startswith("0" * difficulty)
+        pow_primitive = ProofOfWorkPrimitive(difficulty=difficulty)
+        block_hash = block_data.get("hash", "")
+        return pow_primitive.verify_proof(challenge_hash, nonce, block_hash)
 
     @staticmethod
     def find_proof_of_work(block_data: Dict, difficulty: int) -> tuple:
-        """Find a nonce that satisfies the proof-of-work requirement"""
-        # Create copy of block data without the nonce to create the challenge
-        challenge = {k: v for k, v in block_data.items() if k != "nonce"}
+        """
+        Find PoW using the shared Chaincraft primitive.
+        """
+        challenge = {k: v for k, v in block_data.items() if k not in ("nonce", "hash")}
         challenge_hash = BlockchainUtils.calculate_hash(challenge)
-
-        nonce = 0
-        max_nonce = 2**32  # Prevent infinite loops
-
-        while nonce < max_nonce:
-            # Combine challenge hash with nonce to get final hash
-            final_hash = BlockchainUtils.calculate_hash(challenge_hash + str(nonce))
-
-            # Check if hash meets difficulty
-            if final_hash.startswith("0" * difficulty):
-                return nonce, final_hash
-
-            nonce += 1
-
-        raise Exception(f"Couldn't find valid proof after {max_nonce} attempts")
+        pow_primitive = ProofOfWorkPrimitive(difficulty=difficulty)
+        return pow_primitive.create_proof(challenge_hash)
 
     @staticmethod
     def generate_keypair() -> tuple:
         """Generate ECDSA keypair for transaction signing"""
-        private_key = ec.generate_private_key(ec.SECP256K1)
-        public_key = private_key.public_key()
+        private_key, public_key = generate_key_pair()
 
         # Convert to strings for storage/transmission
         private_key_str = private_key.private_bytes(
@@ -106,19 +112,7 @@ class BlockchainUtils:
         try:
             # Load the public key from PEM format
             key = serialization.load_pem_public_key(public_key.encode())
-
-            # Get public key in raw bytes format
-            public_key_bytes = key.public_bytes(
-                encoding=serialization.Encoding.X962,
-                format=serialization.PublicFormat.UncompressedPoint,
-            )
-
-            # Remove the first byte (0x04 for uncompressed keys) and hash
-            public_key_bytes = public_key_bytes[1:]
-
-            # Hash the public key and take last 20 bytes (like Ethereum)
-            address = hashlib.sha256(public_key_bytes).digest()[-20:].hex()
-            return f"0x{address}"
+            return public_key_to_address(key)
         except Exception as e:
             print(f"Error generating address: {e}")
             return f"0x{'0' * 40}"  # Return invalid address in case of error
@@ -130,13 +124,14 @@ class BlockchainUtils:
         tx_copy = {k: v for k, v in tx_data.items() if k != "signature"}
         message = json.dumps(tx_copy, sort_keys=True).encode()
 
-        # Load private key from PEM string
+        # Reuse the framework signing primitive.
         private_key = serialization.load_pem_private_key(
             private_key_str.encode(), password=None
         )
-
-        # Sign the message using deterministic ECDSA (RFC 6979)
-        signature = private_key.sign(message, ec.ECDSA(hashes.SHA256()))
+        signer = ECDSASignaturePrimitive()
+        signer.private_key = private_key
+        signer.public_key = private_key.public_key()
+        signature = signer.sign(message)
 
         # Convert to hex
         return signature.hex()
@@ -145,19 +140,20 @@ class BlockchainUtils:
     def verify_signature(tx_data: Dict, signature: str, public_key_str: str) -> bool:
         """Verify transaction signature with public key"""
         # Remove signature field if present when verifying
-        tx_copy = {k: v for k, v in tx_data.items() if k != "signature"}
+        tx_copy = {
+            k: v
+            for k, v in tx_data.items()
+            if k not in ("signature", "public_key", "tx_id")
+        }
         message = json.dumps(tx_copy, sort_keys=True).encode()
 
         try:
             # Convert hex string to bytes for signature
             signature_bytes = bytes.fromhex(signature)
 
-            # Load public key from PEM string
-            public_key = serialization.load_pem_public_key(public_key_str.encode())
-
-            # Verify the signature
-            public_key.verify(signature_bytes, message, ec.ECDSA(hashes.SHA256()))
-            return True
+            verifier = ECDSASignaturePrimitive()
+            verifier.load_pub_key_from_pem(public_key_str)
+            return verifier.verify(message, signature_bytes)
         except Exception as e:
             print(f"Signature verification error: {e}")
             return False
@@ -169,8 +165,8 @@ class Transaction:
 
     sender: str  # Sender's address
     recipient: str  # Recipient's address
-    amount: float  # Amount to transfer
-    fee: float  # Transaction fee
+    amount: int  # Amount to transfer (integer units)
+    fee: int  # Transaction fee (integer units)
     timestamp: float  # Transaction creation time
     public_key: str  # Sender's public key (for verification)
     signature: str  # Transaction signature
@@ -181,12 +177,21 @@ class Transaction:
         cls,
         sender: str,
         recipient: str,
-        amount: float,
-        fee: float,
+        amount: int,
+        fee: int,
         private_key: str,
         public_key: str,
     ) -> "Transaction":
         """Create and sign a new transaction"""
+        if not isinstance(amount, int) or isinstance(amount, bool):
+            raise ValueError("amount must be an integer")
+        if not isinstance(fee, int) or isinstance(fee, bool):
+            raise ValueError("fee must be an integer")
+        if amount <= 0:
+            raise ValueError("amount must be positive")
+        if fee < 0:
+            raise ValueError("fee must be non-negative")
+
         # Basic transaction data
         tx_data = {
             "sender": sender,
@@ -251,6 +256,15 @@ class Transaction:
                 "signature",
                 "tx_id",
             ]
+        ):
+            return False
+
+        # Check that amount/fee are integer-denominated consensus values.
+        if (
+            not isinstance(self.amount, int)
+            or isinstance(self.amount, bool)
+            or not isinstance(self.fee, int)
+            or isinstance(self.fee, bool)
         ):
             return False
 
@@ -396,7 +410,7 @@ class Mempool(CoreMempool):
             print(f"Error validating message: {e}")
             return False
 
-    def add_message(self, message: SharedMessage) -> None:
+    def add_message(self, message: SharedMessage, frontier_state=None) -> None:
         """
         Process a new message - either a transaction to add to mempool
         or a block that will clear transactions from the mempool
@@ -415,17 +429,28 @@ class Mempool(CoreMempool):
 
         # Handle block message
         elif isinstance(data, dict) and "type" in data and data["type"] == "block":
-            block_data = data["payload"]
-            block = Block.from_dict(block_data)
+            metadata = {}
+            if frontier_state is not None and hasattr(frontier_state, "metadata"):
+                metadata = dict(frontier_state.metadata or {})
 
-            # Remove transactions included in the block from mempool
-            for tx_dict in block.transactions:
-                tx_id = tx_dict["tx_id"]
-                if tx_id in self.transactions:
-                    del self.transactions[tx_id]
+            reverted_txs = metadata.get("reverted_txs", [])
+            applied_tx_ids = metadata.get("applied_tx_ids", [])
 
-            n = len(block.transactions)
-            print(f"Cleared {n} transactions from mempool after block {block.index}")
+            # Re-introduce transactions from reverted canonical blocks.
+            for tx_dict in reverted_txs:
+                tx = Transaction.from_dict(tx_dict)
+                self.transactions[tx.tx_id] = tx
+
+            # Remove transactions confirmed in the new canonical branch.
+            if applied_tx_ids:
+                for tx_id in applied_tx_ids:
+                    self.transactions.pop(tx_id, None)
+            else:
+                # Fallback path: remove txs in this block payload.
+                block_data = data["payload"]
+                block = Block.from_dict(block_data)
+                for tx_dict in block.transactions:
+                    self.transactions.pop(tx_dict["tx_id"], None)
 
     def get_transactions_by_fee(self, max_count: int = 10) -> List[Transaction]:
         """Get transactions sorted by fee (highest first), up to max_count"""
@@ -441,19 +466,32 @@ class Ledger(CoreBlockchain):
     and tracks account balances. Merklelized for efficient state sync.
     """
 
-    def __init__(self, difficulty: int = 4, reward: float = 10.0):
+    def __init__(self, difficulty: int = 4, reward: int = 10):
         """Initialize blockchain with genesis block"""
         super().__init__()
         self.chain: List[Block] = []
-        self.balances: Dict[str, float] = {}  # address -> balance
+        self.balances: Dict[str, int] = {}  # canonical address -> balance
         self.difficulty = difficulty
+        if not isinstance(reward, int) or isinstance(reward, bool):
+            raise ValueError("reward must be an integer")
+        if reward < 0:
+            raise ValueError("reward must be non-negative")
         self.mining_reward = reward
+        self.block_by_hash: Dict[str, Dict[str, Any]] = {}
+        self.children_by_hash: Dict[str, Set[str]] = {}
+        self.tip_hashes: Set[str] = set()
+        self.state_by_hash: Dict[str, Dict[str, int]] = {}
 
         # Create genesis block
         self._create_genesis_block()
 
         # Save chain hashes for merklelization
         self.chain_hashes: List[str] = [self.chain[0].hash]
+        genesis_hash = self.chain[0].hash
+        self.block_by_hash[genesis_hash] = self.chain[0].to_dict()
+        self.children_by_hash[genesis_hash] = set()
+        self.tip_hashes.add(genesis_hash)
+        self.state_by_hash[genesis_hash] = dict(self.balances)
 
     def _create_genesis_block(self) -> None:
         """Create the genesis (first) block in the chain"""
@@ -478,7 +516,7 @@ class Ledger(CoreBlockchain):
         self.chain.append(genesis_block)
 
         # Give genesis address some coins
-        self.balances[genesis_address] = 1000.0
+        self.balances[genesis_address] = 1000
 
     def is_valid(self, message: SharedMessage) -> bool:
         """
@@ -487,7 +525,17 @@ class Ledger(CoreBlockchain):
         try:
             data = message.data
 
-            # Only accept block messages
+            # Allow transaction messages so Mempool + Ledger can coexist in pipeline.
+            if (
+                isinstance(data, dict)
+                and "type" in data
+                and data["type"] == "transaction"
+            ):
+                tx_data = data["payload"]
+                tx = Transaction.from_dict(tx_data)
+                return tx.is_valid()
+
+            # Block messages can extend any known parent (fork-aware).
             if isinstance(data, dict) and "type" in data and data["type"] == "block":
                 block_data = data["payload"]
                 block = Block.from_dict(block_data)
@@ -497,19 +545,23 @@ class Ledger(CoreBlockchain):
                     print("Invalid block: Failed proof-of-work check")
                     return False
 
-                # Check block index
-                if block.index != len(self.chain):
+                if block.previous_hash not in self.block_by_hash:
+                    print("Invalid block: Unknown previous hash")
+                    return False
+
+                parent = self.block_by_hash[block.previous_hash]
+                expected_index = int(parent["index"]) + 1
+                if block.index != expected_index:
                     print(
-                        f"Invalid block: Expected index {len(self.chain)}, got {block.index}"
+                        f"Invalid block: Expected index {expected_index}, got {block.index}"
                     )
                     return False
 
-                # Check previous hash
-                if block.previous_hash != self.chain[-1].hash:
-                    print("Invalid block: Previous hash doesn't match")
-                    return False
-
                 # Validate each transaction in the block
+                simulated_balances = dict(self.state_by_hash[block.previous_hash])
+                simulated_balances[block.miner] = (
+                    simulated_balances.get(block.miner, 0) + self.mining_reward
+                )
                 for tx_dict in block.transactions:
                     tx = Transaction.from_dict(tx_dict)
 
@@ -519,10 +571,17 @@ class Ledger(CoreBlockchain):
                         return False
 
                     # Check sender has enough balance
-                    sender_balance = self.balances.get(tx.sender, 0)
+                    sender_balance = simulated_balances.get(tx.sender, 0)
                     if sender_balance < tx.amount + tx.fee:
                         print(f"Insufficient balance for tx {tx.tx_id[:8]}")
                         return False
+                    simulated_balances[tx.sender] = sender_balance - tx.amount - tx.fee
+                    simulated_balances[tx.recipient] = (
+                        simulated_balances.get(tx.recipient, 0) + tx.amount
+                    )
+                    simulated_balances[block.miner] = (
+                        simulated_balances.get(block.miner, 0) + tx.fee
+                    )
 
                 return True
 
@@ -531,24 +590,115 @@ class Ledger(CoreBlockchain):
             print(f"Error validating block message: {e}")
             return False
 
-    def add_message(self, message: SharedMessage) -> None:
+    def add_message(
+        self, message: SharedMessage, frontier_state=None
+    ) -> Optional[StateMemento]:
         """
         Process a new block and update the chain and balances
         """
         data = message.data
 
+        # Ignore tx messages in ledger state transitions.
+        if isinstance(data, dict) and data.get("type") == "transaction":
+            return self.emit_state_memento()
+
         # Only process block messages
         if isinstance(data, dict) and "type" in data and data["type"] == "block":
             block_data = data["payload"]
             block = Block.from_dict(block_data)
+            block_hash = block.hash
 
-            # Process the block
-            self._add_block(block)
+            if block_hash in self.block_by_hash:
+                return self.emit_state_memento()
 
-            # Update merklelized chain hashes
-            self.chain_hashes.append(block.hash)
+            parent_hash = block.previous_hash
+            parent_state = dict(self.state_by_hash[parent_hash])
+            next_state = self._compute_next_state(parent_state, block)
 
-            print(f"Added block {block.index} to chain, hash: {block.hash[:8]}")
+            block_dict = block.to_dict()
+            self.block_by_hash[block_hash] = block_dict
+            self.children_by_hash.setdefault(parent_hash, set()).add(block_hash)
+            self.children_by_hash.setdefault(block_hash, set())
+            self.state_by_hash[block_hash] = next_state
+            self.tip_hashes.add(block_hash)
+            self.tip_hashes.discard(parent_hash)
+
+            old_canonical_hashes = [b.hash for b in self.chain]
+            old_tip_hash = self.chain[-1].hash
+            if self._is_better_tip(block_hash, old_tip_hash):
+                new_chain_dicts = self._build_chain_to_tip(block_hash)
+                if new_chain_dicts:
+                    self.chain = [Block.from_dict(b) for b in new_chain_dicts]
+                    self.chain_hashes = [b["hash"] for b in new_chain_dicts]
+                    self.balances = dict(self.state_by_hash[block_hash])
+
+            new_canonical_hashes = [b.hash for b in self.chain]
+            removed_hashes = [
+                h for h in old_canonical_hashes if h not in set(new_canonical_hashes)
+            ]
+            added_hashes = [
+                h for h in new_canonical_hashes if h not in set(old_canonical_hashes)
+            ]
+            reverted_txs = self._collect_transactions(removed_hashes)
+            applied_txs = self._collect_transactions(added_hashes)
+            applied_tx_ids = [tx["tx_id"] for tx in applied_txs]
+
+            return StateMemento(
+                canonical_digest=self.get_latest_digest(),
+                frontier_digests=tuple(self.get_state_digests()),
+                metadata={
+                    "reorg": len(removed_hashes) > 0,
+                    "reverted_txs": reverted_txs,
+                    "applied_tx_ids": applied_tx_ids,
+                },
+            )
+
+        return self.emit_state_memento()
+
+    def _is_better_tip(self, candidate_hash: str, current_hash: str) -> bool:
+        candidate = self.block_by_hash[candidate_hash]
+        current = self.block_by_hash[current_hash]
+        if candidate["index"] > current["index"]:
+            return True
+        if candidate["index"] < current["index"]:
+            return False
+        return candidate_hash < current_hash
+
+    def _build_chain_to_tip(self, tip_hash: str) -> List[Dict[str, Any]]:
+        chain_reversed: List[Dict[str, Any]] = []
+        cursor_hash = tip_hash
+        while cursor_hash in self.block_by_hash:
+            block = self.block_by_hash[cursor_hash]
+            chain_reversed.append(block)
+            if block["index"] == 0:
+                break
+            cursor_hash = block["previous_hash"]
+        chain = list(reversed(chain_reversed))
+        if not chain or chain[0]["index"] != 0:
+            return []
+        return chain
+
+    def _compute_next_state(
+        self, base_state: Dict[str, int], block: Block
+    ) -> Dict[str, int]:
+        state = dict(base_state)
+        state[block.miner] = state.get(block.miner, 0) + self.mining_reward
+        for tx_dict in block.transactions:
+            tx = Transaction.from_dict(tx_dict)
+            state[tx.sender] = state.get(tx.sender, 0) - tx.amount - tx.fee
+            state[tx.recipient] = state.get(tx.recipient, 0) + tx.amount
+            state[block.miner] = state.get(block.miner, 0) + tx.fee
+        return state
+
+    def _collect_transactions(self, block_hashes: List[str]) -> List[Dict[str, Any]]:
+        txs: List[Dict[str, Any]] = []
+        for block_hash in block_hashes:
+            block = self.block_by_hash.get(block_hash)
+            if not block:
+                continue
+            for tx in block.get("transactions", []):
+                txs.append(tx)
+        return txs
 
     def _add_block(self, block: Block) -> None:
         """Add a validated block to the chain and update balances"""
@@ -582,6 +732,11 @@ class Ledger(CoreBlockchain):
     def get_latest_digest(self) -> str:
         """Return the hash of the latest block"""
         return self.chain[-1].hash
+
+    def get_state_digests(self) -> List[str]:
+        canonical = self.chain_hashes[-8:]
+        extras = sorted(h for h in self.tip_hashes if h not in set(canonical))
+        return canonical + extras
 
     def has_digest(self, hash_digest: str) -> bool:
         """Check if a block with the given hash exists in the chain"""
@@ -646,15 +801,15 @@ class BlockchainNode:
     Helper class to manage blockchain operations for a node
     """
 
-    def __init__(self, chaincraft_node, difficulty: int = 4, reward: float = 10.0):
+    def __init__(self, chaincraft_node, difficulty: int = 4, reward: int = 10):
         """Initialize with ChainCraft node and blockchain configuration"""
         self.node = chaincraft_node
         self.mempool = Mempool(difficulty)
         self.ledger = Ledger(difficulty, reward)
 
         # Add shared objects to the node
-        self.node.add_shared_object(self.mempool)
         self.node.add_shared_object(self.ledger)
+        self.node.add_shared_object(self.mempool)
 
         # Generate key pair for this node
         self.private_key, self.public_key = BlockchainUtils.generate_keypair()
@@ -662,9 +817,7 @@ class BlockchainNode:
 
         print(f"Node initialized with address: {self.address}")
 
-    def create_transaction(
-        self, recipient: str, amount: float, fee: float = 0.01
-    ) -> str:
+    def create_transaction(self, recipient: str, amount: int, fee: int = 1) -> str:
         """Create and broadcast a transaction"""
         # Create transaction
         tx = Transaction.create(
@@ -708,7 +861,7 @@ class BlockchainNode:
 
         return block.hash
 
-    def get_balance(self, address: Optional[str] = None) -> float:
+    def get_balance(self, address: Optional[str] = None) -> int:
         """Get balance for an address or self if None"""
         if address is None:
             address = self.address
@@ -735,9 +888,9 @@ def generate_wallet():
     return {"private_key": private_key, "public_key": public_key, "address": address}
 
 
-def format_balance(balance: float) -> str:
-    """Format balance with 2 decimal places"""
-    return f"{balance:.2f}"
+def format_balance(balance: int) -> str:
+    """Format integer-denominated balance"""
+    return str(balance)
 
 
 if __name__ == "__main__":

--- a/examples/chatroom_protocol.py
+++ b/examples/chatroom_protocol.py
@@ -162,7 +162,7 @@ class ChatroomObject(CoreSharedObject):
 
         return True
 
-    def add_message(self, message: SharedMessage) -> None:
+    def add_message(self, message: SharedMessage, frontier_state=None) -> None:
         data = message.data
         msg_type = data["message_type"]
         cname = data["chatroom_name"]

--- a/examples/randomness_beacon.py
+++ b/examples/randomness_beacon.py
@@ -1,4 +1,4 @@
-from typing import List
+from typing import Dict, List, Optional, Set
 import json
 import hashlib
 import time
@@ -33,9 +33,17 @@ class RandomnessBeacon(MerkelizedObject):
     GENESIS_HASH = "0000000000000000000000000000000000000000000000000000000000000000"
 
     def __init__(self, coinbase_address=None, difficulty_bits=12):
-        self.blocks = []  # List of block headers
-        self.block_by_hash = {}  # Quick lookup by hash
-        self.ledger = {}  # Tracks blocks mined by each address
+        # Canonical chain blocks (genesis -> canonical tip).
+        self.blocks: List[Dict] = []
+        # All known blocks (canonical + side branches), keyed by hash.
+        self.block_by_hash: Dict[str, Dict] = {}
+        # Parent -> children map for fork tracking.
+        self.children_by_hash: Dict[str, Set[str]] = {}
+        # Current frontier tips across all known branches.
+        self.tip_hashes: Set[str] = set()
+        self.ledger: Dict[str, int] = (
+            {}
+        )  # Tracks canonical blocks mined by each address
         self.coinbase_address = coinbase_address  # This node's mining address
         # Convert difficulty_bits to difficulty value (2^difficulty_bits)
         self.difficulty = 2**difficulty_bits
@@ -59,6 +67,8 @@ class RandomnessBeacon(MerkelizedObject):
 
         self.blocks.append(genesis_block)
         self.block_by_hash[genesis_hash] = genesis_block
+        self.children_by_hash[genesis_hash] = set()
+        self.tip_hashes.add(genesis_hash)
 
     def is_valid(self, message: SharedMessage) -> bool:
         """Validate a new block message"""
@@ -89,32 +99,18 @@ class RandomnessBeacon(MerkelizedObject):
             if abs(block["timestamp"] - current_time) > 15:
                 return False
 
-            # Verify block height is valid (next in sequence or replacing last)
-            if (
-                block["blockHeight"] != len(self.blocks)
-                and block["blockHeight"] != len(self.blocks) - 1
-            ):
-                return False
-
-            # For replacement case, verify this is not replacing genesis
+            # Genesis is fixed in this example.
             if block["blockHeight"] == 0:
                 return False
 
-            # Get previous block based on height
-            if block["blockHeight"] == 0:  # Genesis block case
-                prev_block_hash = self.GENESIS_HASH
-            elif block["blockHeight"] > 0 and block["blockHeight"] <= len(self.blocks):
-                # Find previous block hash based on the height
-                prev_height = block["blockHeight"] - 1
-                if prev_height < len(self.blocks):
-                    prev_block_hash = self.blocks[prev_height]["blockHash"]
-                else:
-                    return False
-            else:
+            # Parent must already be known. This enables side-branch growth
+            # and multi-block reorg candidates.
+            prev_hash = block["prevBlockHash"]
+            if prev_hash not in self.block_by_hash:
                 return False
 
-            # Check prev block hash matches expected
-            if block["prevBlockHash"] != prev_block_hash:
+            expected_height = self.block_by_hash[prev_hash]["blockHeight"] + 1
+            if block["blockHeight"] != expected_height:
                 return False
 
             # Calculate block hash if not provided
@@ -134,8 +130,8 @@ class RandomnessBeacon(MerkelizedObject):
             print(f"Block validation error: {str(e)}")
             return False
 
-    def add_message(self, message: SharedMessage) -> None:
-        """Add a valid block to the chain"""
+    def add_message(self, message: SharedMessage, frontier_state=None) -> None:
+        """Add a valid block, track forks, and reorg canonical chain when needed."""
         block = message.data
 
         # Calculate and add block hash if not already provided
@@ -148,87 +144,77 @@ class RandomnessBeacon(MerkelizedObject):
 
         # Acquire lock for thread safety
         with self.block_change_lock:
-            # Check if we're replacing the last block
-            if block["blockHeight"] == len(self.blocks) - 1:
-                self._handle_replacement(block)
-            else:
-                # Add new block
-                self.blocks.append(block)
-                self.block_by_hash[block["blockHash"]] = block
+            parent_hash = block["prevBlockHash"]
+            block_hash = block["blockHash"]
 
-                # Update ledger for miner
-                addr = block["coinbaseAddress"]
-                self.ledger[addr] = self.ledger.get(addr, 0) + 1
+            # Track new block in the full fork graph.
+            self.block_by_hash[block_hash] = block
+            self.children_by_hash.setdefault(parent_hash, set()).add(block_hash)
+            self.children_by_hash.setdefault(block_hash, set())
+            self.tip_hashes.add(block_hash)
+            self.tip_hashes.discard(parent_hash)
 
-                # Signal that a new block was added
-                if block["blockHeight"] > 0:  # Don't signal for genesis
-                    self.block_replacement_event.set()
+            current_tip_hash = self.blocks[-1]["blockHash"]
+            if not self._is_better_candidate(block_hash, current_tip_hash):
+                return
 
-    def _handle_replacement(self, new_block):
-        """Handle potential replacement of the last block"""
-        current_last = self.blocks[-1]
+            new_chain = self._build_chain_to_tip(block_hash)
+            if not new_chain:
+                return
 
-        # Skip if trying to replace genesis
-        if current_last["blockHeight"] == 0:
-            return
-
-        # Only replace if both blocks are at exactly the same height
-        if current_last["blockHeight"] != new_block["blockHeight"]:
-            print(
-                f"Height mismatch: current={current_last['blockHeight']}, new={new_block['blockHeight']} - not replacing"
-            )
-            return
-
-        # Only replace if both blocks have the same previous block hash
-        if current_last["prevBlockHash"] != new_block["prevBlockHash"]:
-            cur = current_last["prevBlockHash"][:8]
-            new = new_block["prevBlockHash"][:8]
-            print(
-                f"Previous hash mismatch: current={cur}..., new={new}... - not replacing"
-            )
-            return
-
-        # Compare lexicographical ordering of block hashes
-        # Lower hash value wins (lexicographically smaller)
-        current_hash = current_last["blockHash"]
-        new_hash = new_block["blockHash"]
-
-        is_own_block = current_last["coinbaseAddress"] == self.coinbase_address
-
-        print(f"Collision detected at height {current_last['blockHeight']}")
-        print(f"Current hash: {current_hash}")
-        print(f"New hash: {new_hash}")
-        print(f"Common prevBlockHash: {current_last['prevBlockHash'][:8]}...")
-        print(f"Is new < current? {new_hash < current_hash}")
-        print(f"Is replacing our own block? {is_own_block}")
-
-        if new_hash < current_hash:  # Lower lexicographical hash value wins
-            print("New block is better - replacing current block")
-            # Decrease ledger for old miner
-            old_addr = current_last["coinbaseAddress"]
-            if old_addr in self.ledger and self.ledger[old_addr] > 0:
-                self.ledger[old_addr] -= 1
-
-            # Remove old block from hash map
-            old_hash = current_last["blockHash"]
-            if old_hash in self.block_by_hash:
-                del self.block_by_hash[old_hash]
-
-            # Remove old block from chain
-            self.blocks.pop()
-
-            # Add new block
-            self.blocks.append(new_block)
-            self.block_by_hash[new_block["blockHash"]] = new_block
-
-            # Update ledger for new miner
-            new_addr = new_block["coinbaseAddress"]
-            self.ledger[new_addr] = self.ledger.get(new_addr, 0) + 1
-
-            # Signal that a block replacement occurred
+            old_tip_hash = current_tip_hash
+            self.blocks = new_chain
+            self._rebuild_ledger_from_canonical()
             self.block_replacement_event.set()
-        else:
-            print("Current block is better - keeping it")
+
+            if old_tip_hash != block_hash:
+                old_short = old_tip_hash[:8]
+                new_short = block_hash[:8]
+                print(
+                    "Canonical chain updated: "
+                    f"{old_short}... -> {new_short}... (height {len(self.blocks)-1})"
+                )
+
+    def _is_better_candidate(self, candidate_hash: str, current_hash: str) -> bool:
+        candidate = self.block_by_hash.get(candidate_hash)
+        current = self.block_by_hash.get(current_hash)
+        if not candidate or not current:
+            return False
+
+        candidate_height = int(candidate["blockHeight"])
+        current_height = int(current["blockHeight"])
+        if candidate_height > current_height:
+            return True
+        if candidate_height < current_height:
+            return False
+
+        # Tie-break at same height: lower hash wins.
+        return candidate_hash < current_hash
+
+    def _build_chain_to_tip(self, tip_hash: str) -> List[Dict]:
+        chain_reversed: List[Dict] = []
+        cursor = self.block_by_hash.get(tip_hash)
+        while cursor is not None:
+            chain_reversed.append(cursor)
+            if cursor["blockHeight"] == 0:
+                break
+            parent_hash = cursor["prevBlockHash"]
+            cursor = self.block_by_hash.get(parent_hash)
+
+        if not chain_reversed or chain_reversed[-1]["blockHeight"] != 0:
+            return []
+        chain = list(reversed(chain_reversed))
+        for i in range(1, len(chain)):
+            expected_height = chain[i - 1]["blockHeight"] + 1
+            if chain[i]["blockHeight"] != expected_height:
+                return []
+        return chain
+
+    def _rebuild_ledger_from_canonical(self) -> None:
+        self.ledger = {}
+        for block in self.blocks[1:]:
+            addr = block["coinbaseAddress"]
+            self.ledger[addr] = self.ledger.get(addr, 0) + 1
 
     def wait_for_block_change(self, timeout=None):
         """Wait for a block replacement event"""
@@ -256,6 +242,15 @@ class RandomnessBeacon(MerkelizedObject):
             return self.GENESIS_HASH
         return self.blocks[-1]["blockHash"]
 
+    def get_state_digests(self) -> List[str]:
+        """
+        SPECS v2 frontier: canonical digest window + all known branch tips.
+        This allows downstream objects to detect multi-block reorgs.
+        """
+        canonical_window = [block["blockHash"] for block in self.blocks[-8:]]
+        extras = sorted(h for h in self.tip_hashes if h not in canonical_window)
+        return canonical_window + extras
+
     def has_digest(self, hash_digest: str) -> bool:
         """Check if we have a block with the given hash"""
         return hash_digest in self.block_by_hash
@@ -282,6 +277,7 @@ class RandomnessBeacon(MerkelizedObject):
                 start_idx = i
                 break
 
+        # If digest is known but not on canonical chain, return no delta.
         if start_idx is None:
             return []
 

--- a/examples/slush_protocol.py
+++ b/examples/slush_protocol.py
@@ -186,7 +186,7 @@ class SlushObject(CoreSharedObject):
     def is_valid(self, message: SharedMessage) -> bool:
         return False
 
-    def add_message(self, message: SharedMessage) -> None:
+    def add_message(self, message: SharedMessage, frontier_state=None) -> None:
         pass
 
 

--- a/examples/snowball_protocol.py
+++ b/examples/snowball_protocol.py
@@ -214,7 +214,7 @@ class SnowballObject(CoreSharedObject):
     def is_valid(self, message: SharedMessage) -> bool:
         return False
 
-    def add_message(self, message: SharedMessage) -> None:
+    def add_message(self, message: SharedMessage, frontier_state=None) -> None:
         pass
 
 

--- a/examples/snowflake_protocol.py
+++ b/examples/snowflake_protocol.py
@@ -199,7 +199,7 @@ class SnowflakeObject(CoreSharedObject):
     def is_valid(self, message: SharedMessage) -> bool:
         return False
 
-    def add_message(self, message: SharedMessage) -> None:
+    def add_message(self, message: SharedMessage, frontier_state=None) -> None:
         pass
 
 

--- a/examples/tendermint_bft.py
+++ b/examples/tendermint_bft.py
@@ -304,7 +304,7 @@ class TendermintBFT(MerkelizedObject):
         # In full implementation, we would verify signatures from 2/3+ of validators
         return True
 
-    def add_message(self, message: SharedMessage) -> None:
+    def add_message(self, message: SharedMessage, frontier_state=None) -> None:
         """Process a consensus message"""
         data = message.data
         message_type = data.get("message_type", "")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "chaincraft"
-version = "0.4.7"
+version = "0.5.0"
 description = "A platform for blockchain education and prototyping"
 readme = "README.md"
 license = { text = "MIT" }

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ from setuptools import setup
 # For backward compatibility with older pip/setuptools versions
 setup(
     name="chaincraft",
-    version="0.4.7",
+    version="0.5.0",
     packages=["chaincraft", "examples"],
     package_data={"": ["*.md", "*.txt"]},
     include_package_data=True,

--- a/tests/test_blockchain_example.py
+++ b/tests/test_blockchain_example.py
@@ -2,13 +2,12 @@ import os
 import sys
 import unittest
 
-try:
-    from chaincraft.shared_message import SharedMessage
-    from examples.blockchain import Block, Ledger, Mempool, Transaction, generate_wallet
-except ImportError:
-    sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
-    from chaincraft.shared_message import SharedMessage
-    from examples.blockchain import Block, Ledger, Mempool, Transaction, generate_wallet
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+if "chaincraft" in sys.modules:
+    del sys.modules["chaincraft"]
+
+from chaincraft.shared_message import SharedMessage
+from examples.blockchain import Block, Ledger, Mempool, Transaction, generate_wallet
 
 
 class TestBlockchainExampleReorgs(unittest.TestCase):

--- a/tests/test_blockchain_example.py
+++ b/tests/test_blockchain_example.py
@@ -1,0 +1,467 @@
+import os
+import sys
+import unittest
+
+try:
+    from chaincraft.shared_message import SharedMessage
+    from examples.blockchain import Block, Ledger, Mempool, Transaction, generate_wallet
+except ImportError:
+    sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+    from chaincraft.shared_message import SharedMessage
+    from examples.blockchain import Block, Ledger, Mempool, Transaction, generate_wallet
+
+
+class TestBlockchainExampleReorgs(unittest.TestCase):
+    def _apply_pipeline(self, ledger: Ledger, mempool: Mempool, payload: dict):
+        message = SharedMessage(data=payload)
+        self.assertTrue(ledger.is_valid(message))
+        self.assertTrue(mempool.is_valid(message))
+        state = ledger.add_message(message)
+        mempool.add_message(message, frontier_state=state)
+        return state
+
+    def _make_fork_block(
+        self,
+        *,
+        index: int,
+        previous_hash: str,
+        miner: str,
+        difficulty: int,
+        transactions=None,
+    ) -> Block:
+        return Block.create(
+            index=index,
+            transactions=transactions or [],
+            previous_hash=previous_hash,
+            miner=miner,
+            difficulty=difficulty,
+        )
+
+    def test_deep_reorg_reintroduces_reverted_transactions(self):
+        ledger = Ledger(difficulty=2, reward=10)
+        mempool = Mempool(difficulty=2)
+
+        wallet_a = generate_wallet()
+        wallet_b = generate_wallet()
+        wallet_c = generate_wallet()
+
+        # Canonical block 1: fund wallet A via mining reward.
+        block1 = ledger.create_block([], wallet_a["address"])
+        self._apply_pipeline(
+            ledger, mempool, {"type": "block", "payload": block1.to_dict()}
+        )
+
+        # Create tx1 and include it in canonical block 2, then add canonical block 3.
+        tx1 = Transaction.create(
+            sender=wallet_a["address"],
+            recipient=wallet_b["address"],
+            amount=3,
+            fee=1,
+            private_key=wallet_a["private_key"],
+            public_key=wallet_a["public_key"],
+        )
+        self._apply_pipeline(
+            ledger, mempool, {"type": "transaction", "payload": tx1.to_dict()}
+        )
+        self.assertIn(tx1.tx_id, mempool.transactions)
+
+        block2 = ledger.create_block([tx1], wallet_a["address"])
+        self._apply_pipeline(
+            ledger, mempool, {"type": "block", "payload": block2.to_dict()}
+        )
+        self.assertNotIn(tx1.tx_id, mempool.transactions)
+
+        block3 = ledger.create_block([], wallet_a["address"])
+        self._apply_pipeline(
+            ledger, mempool, {"type": "block", "payload": block3.to_dict()}
+        )
+
+        # Competing chain from block1: b2 -> b3 -> b4 (longer), no tx1 included.
+        b2 = self._make_fork_block(
+            index=2,
+            previous_hash=block1.hash,
+            miner=wallet_c["address"],
+            difficulty=ledger.difficulty,
+        )
+        b3 = self._make_fork_block(
+            index=3,
+            previous_hash=b2.hash,
+            miner=wallet_c["address"],
+            difficulty=ledger.difficulty,
+        )
+        b4 = self._make_fork_block(
+            index=4,
+            previous_hash=b3.hash,
+            miner=wallet_c["address"],
+            difficulty=ledger.difficulty,
+        )
+
+        state_b2 = self._apply_pipeline(
+            ledger, mempool, {"type": "block", "payload": b2.to_dict()}
+        )
+        state_b3 = self._apply_pipeline(
+            ledger, mempool, {"type": "block", "payload": b3.to_dict()}
+        )
+        state_b4 = self._apply_pipeline(
+            ledger, mempool, {"type": "block", "payload": b4.to_dict()}
+        )
+
+        # Deep reorg dropped canonical block2+block3, so tx1 returns to mempool.
+        self.assertTrue(
+            state_b2.metadata.get("reorg")
+            or state_b3.metadata.get("reorg")
+            or state_b4.metadata.get("reorg")
+        )
+        self.assertEqual(ledger.chain[-1].hash, b4.hash)
+        self.assertIn(tx1.tx_id, mempool.transactions)
+
+    def test_deep_reorg_does_not_reintroduce_reapplied_transaction(self):
+        ledger = Ledger(difficulty=2, reward=10)
+        mempool = Mempool(difficulty=2)
+
+        wallet_a = generate_wallet()
+        wallet_b = generate_wallet()
+        wallet_c = generate_wallet()
+
+        block1 = ledger.create_block([], wallet_a["address"])
+        self._apply_pipeline(
+            ledger, mempool, {"type": "block", "payload": block1.to_dict()}
+        )
+
+        tx1 = Transaction.create(
+            sender=wallet_a["address"],
+            recipient=wallet_b["address"],
+            amount=2,
+            fee=1,
+            private_key=wallet_a["private_key"],
+            public_key=wallet_a["public_key"],
+        )
+        self._apply_pipeline(
+            ledger, mempool, {"type": "transaction", "payload": tx1.to_dict()}
+        )
+        block2 = ledger.create_block([tx1], wallet_a["address"])
+        self._apply_pipeline(
+            ledger, mempool, {"type": "block", "payload": block2.to_dict()}
+        )
+        block3 = ledger.create_block([], wallet_a["address"])
+        self._apply_pipeline(
+            ledger, mempool, {"type": "block", "payload": block3.to_dict()}
+        )
+        self.assertNotIn(tx1.tx_id, mempool.transactions)
+
+        # Competing chain re-applies tx1 while growing longer.
+        b2 = self._make_fork_block(
+            index=2,
+            previous_hash=block1.hash,
+            miner=wallet_c["address"],
+            difficulty=ledger.difficulty,
+        )
+        b3 = self._make_fork_block(
+            index=3,
+            previous_hash=b2.hash,
+            miner=wallet_c["address"],
+            difficulty=ledger.difficulty,
+            transactions=[tx1.to_dict()],
+        )
+        b4 = self._make_fork_block(
+            index=4,
+            previous_hash=b3.hash,
+            miner=wallet_c["address"],
+            difficulty=ledger.difficulty,
+        )
+
+        state_b2 = self._apply_pipeline(
+            ledger, mempool, {"type": "block", "payload": b2.to_dict()}
+        )
+        state_b3 = self._apply_pipeline(
+            ledger, mempool, {"type": "block", "payload": b3.to_dict()}
+        )
+        state_b4 = self._apply_pipeline(
+            ledger, mempool, {"type": "block", "payload": b4.to_dict()}
+        )
+
+        # tx1 was reverted from old canonical but re-applied on new canonical branch.
+        self.assertTrue(
+            state_b2.metadata.get("reorg")
+            or state_b3.metadata.get("reorg")
+            or state_b4.metadata.get("reorg")
+        )
+        self.assertEqual(ledger.chain[-1].hash, b4.hash)
+        self.assertNotIn(tx1.tx_id, mempool.transactions)
+
+
+class TestBlockchainExampleCore(unittest.TestCase):
+    def _make_wallets(self, count: int):
+        return [generate_wallet() for _ in range(count)]
+
+    def test_transaction_tampering_invalidates_signature(self):
+        wallet_a, wallet_b = self._make_wallets(2)
+        tx = Transaction.create(
+            sender=wallet_a["address"],
+            recipient=wallet_b["address"],
+            amount=1,
+            fee=1,
+            private_key=wallet_a["private_key"],
+            public_key=wallet_a["public_key"],
+        )
+        self.assertTrue(tx.is_valid())
+
+        tampered = tx.to_dict()
+        tampered["amount"] = 2
+        tampered_tx = Transaction.from_dict(tampered)
+        self.assertFalse(tampered_tx.is_valid())
+
+    def test_transaction_rejects_non_integer_amount_and_fee(self):
+        wallet_a, wallet_b = self._make_wallets(2)
+        with self.assertRaises(ValueError):
+            Transaction.create(
+                sender=wallet_a["address"],
+                recipient=wallet_b["address"],
+                amount=1.5,
+                fee=1,
+                private_key=wallet_a["private_key"],
+                public_key=wallet_a["public_key"],
+            )
+        with self.assertRaises(ValueError):
+            Transaction.create(
+                sender=wallet_a["address"],
+                recipient=wallet_b["address"],
+                amount=1,
+                fee=0.5,
+                private_key=wallet_a["private_key"],
+                public_key=wallet_a["public_key"],
+            )
+
+    def test_block_tampering_invalidates_pow(self):
+        wallet_a = generate_wallet()
+        block = Block.create(
+            index=1,
+            transactions=[],
+            previous_hash="abc",
+            miner=wallet_a["address"],
+            difficulty=64,
+        )
+        self.assertTrue(block.is_valid(64))
+
+        tampered = block.to_dict()
+        tampered["nonce"] = block.nonce + 1
+        tampered_block = Block.from_dict(tampered)
+        self.assertFalse(tampered_block.is_valid(64))
+
+    def test_ledger_prefers_lower_hash_on_same_height_fork(self):
+        ledger = Ledger(difficulty=2, reward=10)
+        wallet_a, wallet_b = self._make_wallets(2)
+
+        block_a = Block.create(
+            index=1,
+            transactions=[],
+            previous_hash=ledger.chain[-1].hash,
+            miner=wallet_a["address"],
+            difficulty=ledger.difficulty,
+        )
+        block_b = Block.create(
+            index=1,
+            transactions=[],
+            previous_hash=ledger.chain[0].hash,
+            miner=wallet_b["address"],
+            difficulty=ledger.difficulty,
+        )
+
+        msg_a = SharedMessage(data={"type": "block", "payload": block_a.to_dict()})
+        msg_b = SharedMessage(data={"type": "block", "payload": block_b.to_dict()})
+        self.assertTrue(ledger.is_valid(msg_a))
+        self.assertTrue(ledger.is_valid(msg_b))
+        ledger.add_message(msg_a)
+        ledger.add_message(msg_b)
+
+        expected_tip = min(block_a.hash, block_b.hash)
+        self.assertEqual(ledger.chain[-1].hash, expected_tip)
+
+    def test_state_memento_reorg_metadata_shape(self):
+        ledger = Ledger(difficulty=2, reward=10)
+        mempool = Mempool(difficulty=2)
+        wallet_a, wallet_b, wallet_c = self._make_wallets(3)
+
+        # Canonical start.
+        b1 = ledger.create_block([], wallet_a["address"])
+        m1 = SharedMessage(data={"type": "block", "payload": b1.to_dict()})
+        ledger.add_message(m1)
+        mempool.add_message(m1)
+
+        tx = Transaction.create(
+            sender=wallet_a["address"],
+            recipient=wallet_b["address"],
+            amount=2,
+            fee=1,
+            private_key=wallet_a["private_key"],
+            public_key=wallet_a["public_key"],
+        )
+        tmsg = SharedMessage(data={"type": "transaction", "payload": tx.to_dict()})
+        ledger.add_message(tmsg)
+        mempool.add_message(tmsg)
+        b2 = ledger.create_block([tx], wallet_a["address"])
+        m2 = SharedMessage(data={"type": "block", "payload": b2.to_dict()})
+        state2 = ledger.add_message(m2)
+        mempool.add_message(m2, frontier_state=state2)
+
+        # Competing longer branch from b1.
+        c2 = Block.create(2, [], b1.hash, wallet_c["address"], ledger.difficulty)
+        c3 = Block.create(3, [], c2.hash, wallet_c["address"], ledger.difficulty)
+        ledger.add_message(
+            SharedMessage(data={"type": "block", "payload": c2.to_dict()})
+        )
+        state_reorg = ledger.add_message(
+            SharedMessage(data={"type": "block", "payload": c3.to_dict()})
+        )
+
+        self.assertIsNotNone(state_reorg)
+        self.assertIn("reorg", state_reorg.metadata)
+        self.assertIn("reverted_txs", state_reorg.metadata)
+        self.assertIn("applied_tx_ids", state_reorg.metadata)
+        self.assertIsInstance(state_reorg.metadata["reorg"], bool)
+        self.assertIsInstance(state_reorg.metadata["reverted_txs"], list)
+        self.assertIsInstance(state_reorg.metadata["applied_tx_ids"], list)
+
+    def test_get_state_digests_includes_non_canonical_tip(self):
+        ledger = Ledger(difficulty=2, reward=10)
+        wallet_a, wallet_b = self._make_wallets(2)
+
+        # Add canonical height-1 block.
+        canonical = Block.create(
+            1, [], ledger.chain[-1].hash, wallet_a["address"], ledger.difficulty
+        )
+        ledger.add_message(
+            SharedMessage(data={"type": "block", "payload": canonical.to_dict()})
+        )
+
+        # Add side tip at same height from genesis.
+        side = Block.create(
+            1, [], ledger.chain[0].hash, wallet_b["address"], ledger.difficulty
+        )
+        ledger.add_message(
+            SharedMessage(data={"type": "block", "payload": side.to_dict()})
+        )
+
+        digests = ledger.get_state_digests()
+        self.assertIn(canonical.hash, digests)
+        self.assertIn(side.hash, digests)
+
+    def test_mempool_block_fallback_without_memento(self):
+        wallet_a, wallet_b = self._make_wallets(2)
+        tx = Transaction.create(
+            sender=wallet_a["address"],
+            recipient=wallet_b["address"],
+            amount=1,
+            fee=1,
+            private_key=wallet_a["private_key"],
+            public_key=wallet_a["public_key"],
+        )
+        mempool = Mempool(difficulty=2)
+        tmsg = SharedMessage(data={"type": "transaction", "payload": tx.to_dict()})
+        self.assertTrue(mempool.is_valid(tmsg))
+        mempool.add_message(tmsg)
+        self.assertIn(tx.tx_id, mempool.transactions)
+
+        block_payload = {
+            "index": 1,
+            "timestamp": 1.0,
+            "transactions": [tx.to_dict()],
+            "previous_hash": "abc",
+            "miner": wallet_a["address"],
+            "nonce": 0,
+            "hash": "invalid",
+        }
+        # Fallback path ignores frontier metadata and removes tx ids from payload.
+        mempool.add_message(
+            SharedMessage(data={"type": "block", "payload": block_payload}),
+            frontier_state=None,
+        )
+        self.assertNotIn(tx.tx_id, mempool.transactions)
+
+    def test_coinbase_rewards_accumulate_on_canonical_chain(self):
+        ledger = Ledger(difficulty=2, reward=7)
+        miner = generate_wallet()
+
+        # Mine 3 canonical blocks with same miner.
+        for _ in range(3):
+            block = ledger.create_block([], miner["address"])
+            msg = SharedMessage(data={"type": "block", "payload": block.to_dict()})
+            self.assertTrue(ledger.is_valid(msg))
+            ledger.add_message(msg)
+
+        # Fresh miner wallet starts at zero, then accumulates rewards.
+        expected = 3 * 7
+        self.assertEqual(ledger.balances[miner["address"]], expected)
+
+    def test_coinbase_rewards_recomputed_after_deep_reorg(self):
+        ledger = Ledger(difficulty=2, reward=10)
+        miner_a = generate_wallet()
+        miner_b = generate_wallet()
+
+        # Canonical A-chain: G -> A1 -> A2 -> A3
+        a1 = ledger.create_block([], miner_a["address"])
+        ledger.add_message(
+            SharedMessage(data={"type": "block", "payload": a1.to_dict()})
+        )
+        a2 = ledger.create_block([], miner_a["address"])
+        ledger.add_message(
+            SharedMessage(data={"type": "block", "payload": a2.to_dict()})
+        )
+        a3 = ledger.create_block([], miner_a["address"])
+        ledger.add_message(
+            SharedMessage(data={"type": "block", "payload": a3.to_dict()})
+        )
+        self.assertEqual(ledger.chain[-1].hash, a3.hash)
+
+        # Competing B-chain from A1: B2 -> B3 -> B4 (longer, should reorg).
+        b2 = Block.create(2, [], a1.hash, miner_b["address"], ledger.difficulty)
+        b3 = Block.create(3, [], b2.hash, miner_b["address"], ledger.difficulty)
+        b4 = Block.create(4, [], b3.hash, miner_b["address"], ledger.difficulty)
+        for block in (b2, b3, b4):
+            msg = SharedMessage(data={"type": "block", "payload": block.to_dict()})
+            self.assertTrue(ledger.is_valid(msg))
+            ledger.add_message(msg)
+
+        # Canonical should now be G -> A1 -> B2 -> B3 -> B4.
+        self.assertEqual(ledger.chain[-1].hash, b4.hash)
+        self.assertEqual([b.index for b in ledger.chain], [0, 1, 2, 3, 4])
+
+        # Rewards must reflect canonical chain only:
+        # miner_a mined A1 (1 reward), miner_b mined B2/B3/B4 (3 rewards).
+        self.assertEqual(ledger.balances[miner_a["address"]], 10)
+        self.assertEqual(ledger.balances[miner_b["address"]], 30)
+
+    def test_miner_receives_coinbase_reward_plus_fees(self):
+        ledger = Ledger(difficulty=2, reward=10)
+        miner = generate_wallet()
+        sender = generate_wallet()
+        recipient = generate_wallet()
+
+        # Give sender spendable funds by mining one block to sender.
+        funding_block = ledger.create_block([], sender["address"])
+        ledger.add_message(
+            SharedMessage(data={"type": "block", "payload": funding_block.to_dict()})
+        )
+
+        tx = Transaction.create(
+            sender=sender["address"],
+            recipient=recipient["address"],
+            amount=4,
+            fee=1,
+            private_key=sender["private_key"],
+            public_key=sender["public_key"],
+        )
+        block = ledger.create_block([tx], miner["address"])
+        msg = SharedMessage(data={"type": "block", "payload": block.to_dict()})
+        self.assertTrue(ledger.is_valid(msg))
+        ledger.add_message(msg)
+
+        # Miner gets reward + fee.
+        self.assertEqual(ledger.balances[miner["address"]], 11)
+        # Sender had 10 from funding block, spent 4 + 1.
+        self.assertEqual(ledger.balances[sender["address"]], 5)
+        self.assertEqual(ledger.balances[recipient["address"]], 4)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_core_objects.py
+++ b/tests/test_core_objects.py
@@ -1,6 +1,7 @@
 import os
 import sys
 import unittest
+from typing import Optional
 
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 if "chaincraft" in sys.modules:
@@ -21,6 +22,7 @@ from chaincraft.core_objects import (
     UTXOLedger,
 )
 from chaincraft.node import ChaincraftNode
+from chaincraft.state_memento import StateMemento, normalize_state_memento
 from chaincraft.shared_message import SharedMessage
 
 
@@ -572,6 +574,86 @@ class TestAdditionalCacheCases(unittest.TestCase):
         docs.add_message(SharedMessage(data={"doc_id": "missing", "action": "delete"}))
         self.assertEqual(len(docs.documents), 0)
         self.assertEqual(len(docs.cache), 0)
+
+
+class _FrontierSourceObject(NonMerkelizedObject):
+    def is_valid(self, message: SharedMessage) -> bool:
+        return isinstance(message.data, dict)
+
+    def add_message(
+        self,
+        message: SharedMessage,
+        frontier_state: Optional[StateMemento] = None,
+    ) -> StateMemento:
+        payload = message.data
+        canonical = payload.get("canonical", "")
+        frontier = payload.get("frontier", [])
+        return normalize_state_memento(canonical, frontier)
+
+
+class _FrontierObserverObject(NonMerkelizedObject):
+    def __init__(self):
+        super().__init__()
+        self.seen_frontiers = []
+        self.reorg_flags = []
+        self._last_frontier = None
+
+    def is_valid(self, message: SharedMessage) -> bool:
+        return isinstance(message.data, dict)
+
+    def add_message(
+        self,
+        message: SharedMessage,
+        frontier_state: Optional[StateMemento] = None,
+    ) -> None:
+        if frontier_state is None:
+            return
+
+        self.seen_frontiers.append(frontier_state)
+        self.reorg_flags.append(
+            frontier_state.indicates_reorg_against(self._last_frontier)
+        )
+        self._last_frontier = frontier_state
+
+
+class TestPipelineStateMementos(unittest.TestCase):
+    def test_node_passes_frontier_memento_between_shared_objects(self):
+        source = _FrontierSourceObject()
+        observer = _FrontierObserverObject()
+        node = ChaincraftNode(persistent=False, shared_objects=[source, observer])
+        node.create_shared_message(
+            {
+                "canonical": "d2",
+                "frontier": ["d0", "d1", "d2"],
+            }
+        )
+        self.assertEqual(len(observer.seen_frontiers), 1)
+        self.assertEqual(observer.seen_frontiers[0].canonical_digest, "d2")
+        self.assertEqual(
+            observer.seen_frontiers[0].frontier_digests, ("d0", "d1", "d2")
+        )
+
+    def test_reorg_detection_works_for_multi_block_rewrite(self):
+        source = _FrontierSourceObject()
+        observer = _FrontierObserverObject()
+        node = ChaincraftNode(persistent=False, shared_objects=[source, observer])
+
+        node.create_shared_message(
+            {
+                "canonical": "c3",
+                "frontier": ["c1", "c2", "c3"],
+            }
+        )
+        node.create_shared_message(
+            {
+                "canonical": "f4",
+                "frontier": ["f2", "f3", "f4"],
+            }
+        )
+
+        self.assertEqual(len(observer.reorg_flags), 2)
+        self.assertEqual(observer.reorg_flags[0], False)
+        self.assertEqual(observer.reorg_flags[1], True)
 
 
 if __name__ == "__main__":

--- a/tests/test_crypto_primitives.py
+++ b/tests/test_crypto_primitives.py
@@ -11,6 +11,7 @@ try:
     from chaincraft.crypto_primitives.sign import ECDSASignaturePrimitive
     from chaincraft.crypto_primitives.vrf import ECDSAVRFPrimitive
     from chaincraft.crypto_primitives.encrypt import SymmetricEncryption
+    from examples.blockchain import BlockchainUtils
 except ImportError:
     # Add parent directory to path as fallback
     sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
@@ -19,6 +20,7 @@ except ImportError:
     from chaincraft.crypto_primitives.sign import ECDSASignaturePrimitive
     from chaincraft.crypto_primitives.vrf import ECDSAVRFPrimitive
     from chaincraft.crypto_primitives.encrypt import SymmetricEncryption
+    from examples.blockchain import BlockchainUtils
 
 
 class TestCryptoPrimitives(unittest.TestCase):
@@ -37,6 +39,34 @@ class TestCryptoPrimitives(unittest.TestCase):
 
         # Test with incorrect nonce
         self.assertFalse(pow_primitive.verify_proof(challenge, nonce + 1, hash_hex))
+
+        # Test with incorrect hash
+        bad_hash = "0" * len(hash_hex)
+        self.assertFalse(pow_primitive.verify_proof(challenge, nonce, bad_hash))
+
+    def test_pow_blockchain_utils_use_shared_primitive(self):
+        difficulty = 64
+        block_data = {
+            "index": 1,
+            "timestamp": 1234567890,
+            "transactions": [],
+            "previous_hash": "abc",
+            "miner": "miner-x",
+        }
+        nonce, block_hash = BlockchainUtils.find_proof_of_work(block_data, difficulty)
+        payload = dict(block_data)
+        payload["nonce"] = nonce
+        payload["hash"] = block_hash
+        self.assertTrue(
+            BlockchainUtils.verify_proof_of_work(payload, nonce, difficulty)
+        )
+
+        # Mutating any signed field must invalidate proof.
+        tampered = dict(payload)
+        tampered["previous_hash"] = "def"
+        self.assertFalse(
+            BlockchainUtils.verify_proof_of_work(tampered, nonce, difficulty)
+        )
 
     def test_vdf(self):
         # Use fewer iterations for testing speed

--- a/tests/test_randomness_beacon.py
+++ b/tests/test_randomness_beacon.py
@@ -436,12 +436,14 @@ class TestRandomnessBeacon(unittest.TestCase):
     def test_randomness_distribution(self):
         """Test that the randomness has good distribution properties"""
         coinbase = generate_eth_address()
+        # Use lower difficulty for this statistical test to keep runtime short.
+        fast_difficulty_bits = max(4, self.__DIFFICULTY - 6)
         beacon = RandomnessBeacon(
-            coinbase_address=coinbase, difficulty_bits=self.__DIFFICULTY
+            coinbase_address=coinbase, difficulty_bits=fast_difficulty_bits
         )
 
         # Mine many blocks for better statistical analysis
-        num_blocks = 20
+        num_blocks = 10
         for _ in range(num_blocks):
             block = beacon.mine_block()
             beacon.add_message(SharedMessage(data=block))
@@ -482,11 +484,128 @@ class TestRandomnessBeacon(unittest.TestCase):
         print(f"Overall bit distribution: {zeros_total} zeros, {ones_total} ones")
         print(f"Percentages: {zero_percent:.2f}% zeros, {one_percent:.2f}% ones")
 
-        # Should be close to 50/50 (allow 5% deviation)
-        self.assertGreaterEqual(zero_percent, 45)
-        self.assertLessEqual(zero_percent, 55)
-        self.assertGreaterEqual(one_percent, 45)
-        self.assertLessEqual(one_percent, 55)
+        # Should be close to 50/50. With fewer samples allow wider margin.
+        self.assertGreaterEqual(zero_percent, 42)
+        self.assertLessEqual(zero_percent, 58)
+        self.assertGreaterEqual(one_percent, 42)
+        self.assertLessEqual(one_percent, 58)
+
+    def test_multi_block_reorg_longer_fork_wins(self):
+        """A longer fork should replace canonical chain by >1 block."""
+        addr_a = generate_eth_address()
+        addr_b = generate_eth_address()
+        beacon = RandomnessBeacon(coinbase_address=addr_a, difficulty_bits=3)
+
+        # Build initial canonical chain: genesis -> a1 -> a2
+        a1 = beacon.mine_block()
+        beacon.add_message(SharedMessage(data=a1))
+        a2 = beacon.mine_block()
+        beacon.add_message(SharedMessage(data=a2))
+        self.assertEqual(len(beacon.blocks), 3)
+        old_tip = beacon.blocks[-1]["blockHash"]
+
+        def _mine_on_parent(parent_hash: str, height: int, miner: str) -> dict:
+            block = {
+                "message_type": "BEACON_BLOCK",
+                "blockHeight": height,
+                "prevBlockHash": parent_hash,
+                "timestamp": int(time.time()),
+                "coinbaseAddress": miner,
+                "nonce": 0,
+            }
+            challenge = miner + parent_hash
+            nonce, block_hash = beacon.pow_primitive.create_proof(challenge)
+            block["nonce"] = nonce
+            block["blockHash"] = block_hash
+            return block
+
+        # Build competing fork: genesis -> b1 -> b2 -> b3
+        genesis_hash = beacon.blocks[0]["blockHash"]
+        b1 = _mine_on_parent(genesis_hash, 1, addr_b)
+        b2 = _mine_on_parent(b1["blockHash"], 2, addr_b)
+        b3 = _mine_on_parent(b2["blockHash"], 3, addr_b)
+
+        for blk in (b1, b2, b3):
+            self.assertTrue(beacon.is_valid(SharedMessage(data=blk)))
+            beacon.add_message(SharedMessage(data=blk))
+
+        self.assertEqual(len(beacon.blocks), 4)
+        self.assertEqual(beacon.blocks[-1]["blockHash"], b3["blockHash"])
+        self.assertNotEqual(old_tip, beacon.blocks[-1]["blockHash"])
+        self.assertEqual(beacon.ledger.get(addr_b, 0), 3)
+        self.assertEqual(beacon.ledger.get(addr_a, 0), 0)
+
+    def test_deep_reorg_drops_multiple_head_blocks(self):
+        """
+        Reorg should be able to drop more than one head block.
+        Example:
+          canonical: G -> A1 -> A2 -> A3 -> A4 -> A5
+          competing: G -> A1 -> A2 -> B3 -> B4 -> B5 -> B6
+        The canonical chain must switch to the B-branch, dropping A3/A4/A5.
+        """
+        addr_a = generate_eth_address()
+        addr_b = generate_eth_address()
+        beacon = RandomnessBeacon(coinbase_address=addr_a, difficulty_bits=3)
+
+        def _mine_on_parent(parent_hash: str, height: int, miner: str) -> dict:
+            block = {
+                "message_type": "BEACON_BLOCK",
+                "blockHeight": height,
+                "prevBlockHash": parent_hash,
+                "timestamp": int(time.time()),
+                "coinbaseAddress": miner,
+                "nonce": 0,
+            }
+            challenge = miner + parent_hash
+            nonce, block_hash = beacon.pow_primitive.create_proof(challenge)
+            block["nonce"] = nonce
+            block["blockHash"] = block_hash
+            return block
+
+        # Build canonical A-branch to height 5.
+        a_blocks = []
+        for _ in range(5):
+            new_block = beacon.mine_block()
+            beacon.add_message(SharedMessage(data=new_block))
+            a_blocks.append(new_block)
+
+        self.assertEqual(len(beacon.blocks), 6)  # genesis + 5
+        self.assertEqual(beacon.blocks[-1]["blockHash"], a_blocks[-1]["blockHash"])
+
+        # Fork from A2 (height 2) and extend to B6 (height 6).
+        fork_parent = a_blocks[1]["blockHash"]  # A2
+        b3 = _mine_on_parent(fork_parent, 3, addr_b)
+        b4 = _mine_on_parent(b3["blockHash"], 4, addr_b)
+        b5 = _mine_on_parent(b4["blockHash"], 5, addr_b)
+        b6 = _mine_on_parent(b5["blockHash"], 6, addr_b)
+
+        for blk in (b3, b4, b5, b6):
+            msg = SharedMessage(data=blk)
+            self.assertTrue(beacon.is_valid(msg))
+            beacon.add_message(msg)
+
+        # Canonical chain should now be G, A1, A2, B3, B4, B5, B6.
+        self.assertEqual(len(beacon.blocks), 7)
+        self.assertEqual(beacon.blocks[-1]["blockHash"], b6["blockHash"])
+        self.assertEqual(beacon.blocks[1]["blockHash"], a_blocks[0]["blockHash"])  # A1
+        self.assertEqual(beacon.blocks[2]["blockHash"], a_blocks[1]["blockHash"])  # A2
+        self.assertEqual(beacon.blocks[3]["blockHash"], b3["blockHash"])
+        self.assertEqual(beacon.blocks[4]["blockHash"], b4["blockHash"])
+        self.assertEqual(beacon.blocks[5]["blockHash"], b5["blockHash"])
+        self.assertEqual(beacon.blocks[6]["blockHash"], b6["blockHash"])
+
+        # Old A-head blocks must not remain canonical.
+        dropped_hashes = {
+            a_blocks[2]["blockHash"],
+            a_blocks[3]["blockHash"],
+            a_blocks[4]["blockHash"],
+        }
+        canonical_hashes = {b["blockHash"] for b in beacon.blocks}
+        self.assertTrue(dropped_hashes.isdisjoint(canonical_hashes))
+
+        # Ledger must match canonical branch only: A mined A1/A2, B mined B3..B6.
+        self.assertEqual(beacon.ledger.get(addr_a, 0), 2)
+        self.assertEqual(beacon.ledger.get(addr_b, 0), 4)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
closes #85
closes #86 

## Summary
- Introduce v2-style linear `SharedObject` pipeline propagation using `StateMemento` (`canonical_digest`, `frontier_digests`, metadata) so downstream objects can detect and react to reorgs.
- Extend examples (`blockchain`, `randomness_beacon`, consensus examples) to align with frontier/memento propagation and multi-block reorg behavior.
- Refactor `examples/blockchain.py` to reuse shared crypto primitives and enforce integer-denominated `amount`/`fee`/`reward`/balances for deterministic consensus behavior.
- Expand and update tests, including deep reorg + mempool reinsertion logic and coinbase/balance-focused coverage in `tests/test_blockchain_example.py`.
- Bump version references to `0.5.0` and update `SPECS.md` minimally to reflect v2 behavior.

## Why
- Reorg awareness needs to flow through the `Node` shared-object pipeline, not stay local to a single object.
- Multi-block reorgs require canonical/frontier signaling plus deterministic state recomputation.
- Float arithmetic in consensus paths is risky; integer units avoid precision/divergence issues across environments.

## Test Plan
- `python -m unittest -v tests/test_blockchain_example.py`
- `python -m unittest -v tests/test_randomness_beacon.py`
- `python -m unittest -v tests/test_crypto_primitives.py`
- `python -m unittest -v tests/test_core_objects.py`